### PR TITLE
config: Add default 'left' position to bar config

### DIFF
--- a/plugin/src/Caelestia/Config/barconfig.hpp
+++ b/plugin/src/Caelestia/Config/barconfig.hpp
@@ -130,6 +130,7 @@ class BarConfig : public ConfigObject {
     CONFIG_PROPERTY(bool, persistent, true)
     CONFIG_PROPERTY(bool, showOnHover, true)
     CONFIG_PROPERTY(int, dragThreshold, 20)
+    CONFIG_PROPERTY(QString, position, u"left"_s)
     CONFIG_SUBOBJECT(BarScrollActions, scrollActions)
     CONFIG_SUBOBJECT(BarPopouts, popouts)
     CONFIG_SUBOBJECT(BarWorkspaces, workspaces)


### PR DESCRIPTION
Previously, bar position defaulted to undefined in QML which required manual null coalescing. Now BarConfig has an explicit position property with a default value of 'left', so users don't need to specify it.