### PR TITLE
Fix cd for terminal tab

### DIFF
--- a/modules/dashboard/TerminalTab.qml
+++ b/modules/dashboard/TerminalTab.qml
@@ -168,6 +168,7 @@ Item {
         }
         pwdResolverComp.createObject(root, {
             command: ["fish", "-c", "cd " + path + " && pwd"],
+            workingDirectory: currentDirectory,
             running: true
         });
     }


### PR DESCRIPTION
 workingDirectory: currentDirectory,
 Basically so if you cd somewhere, you don't cd relative to home, but current directory. So cd .. doesn't put you in /home always. And also so you can do smth like this, cd Journal, then cd 2026, instead of cd Journal/2026