### PR TITLE
feat: Change logo size to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,10 @@ For example, to disable the bar on DP-1:
                 }
             ]
         },
-        "logo": "",
+        "logo": {
+            "path": "",
+            "size": 32
+        },
         "mediaGifSpeedAdjustment": 300,
         "sessionGifSpeed": 0.7,
         "showOverFullscreen": false

--- a/modules/bar/components/OsIcon.qml
+++ b/modules/bar/components/OsIcon.qml
@@ -8,8 +8,8 @@ import qs.utils
 Item {
     id: root
 
-    implicitWidth: Math.round(Tokens.font.body.large.pointSize * 1.2)
-    implicitHeight: Math.round(Tokens.font.body.large.pointSize * 1.2)
+    implicitWidth: Math.round(GlobalConfig.general.logo.size)
+    implicitHeight: Math.round(GlobalConfig.general.logo.size)
 
     MouseArea {
         anchors.fill: parent
@@ -30,8 +30,8 @@ Item {
         id: caelestiaLogo
 
         Logo {
-            implicitWidth: Math.round(Tokens.font.body.large.pointSize * 1.6)
-            implicitHeight: Math.round(Tokens.font.body.large.pointSize * 1.6)
+            implicitWidth: Math.round(GlobalConfig.general.logo.size)
+            implicitHeight: Math.round(GlobalConfig.general.logo.size)
         }
     }
 
@@ -40,7 +40,7 @@ Item {
 
         ColouredIcon {
             source: SysInfo.osLogo
-            implicitSize: Math.round(Tokens.font.body.large.pointSize * 1.2)
+            implicitSize: Math.round(GlobalConfig.general.logo.size)
             colour: Colours.palette.m3tertiary
         }
     }

--- a/plugin/src/Caelestia/Config/generalconfig.hpp
+++ b/plugin/src/Caelestia/Config/generalconfig.hpp
@@ -94,24 +94,37 @@ public:
         : ConfigObject(parent) {}
 };
 
+class LogoConfig : public ConfigObject {
+    Q_OBJECT
+    QML_ANONYMOUS
+
+    CONFIG_GLOBAL_PROPERTY(QString, path, u""_s)
+    CONFIG_GLOBAL_PROPERTY(int, size, 32)
+
+public:
+    explicit LogoConfig(QObject* parent = nullptr)
+        : ConfigObject(parent) {}
+};
+
 class GeneralConfig : public ConfigObject {
     Q_OBJECT
     QML_ANONYMOUS
 
-    CONFIG_GLOBAL_PROPERTY(QString, logo)
     CONFIG_PROPERTY(bool, showOverFullscreen, false)
     CONFIG_PROPERTY(qreal, mediaGifSpeedAdjustment, 300)
     CONFIG_PROPERTY(qreal, sessionGifSpeed, 0.7)
     CONFIG_SUBOBJECT(GeneralApps, apps)
     CONFIG_SUBOBJECT(GeneralIdle, idle)
     CONFIG_SUBOBJECT(GeneralBattery, battery)
+    CONFIG_SUBOBJECT(LogoConfig, logo)
 
 public:
     explicit GeneralConfig(QObject* parent = nullptr)
         : ConfigObject(parent)
         , m_apps(new GeneralApps(this))
         , m_idle(new GeneralIdle(this))
-        , m_battery(new GeneralBattery(this)) {}
+        , m_battery(new GeneralBattery(this))
+        , m_logo(new LogoConfig(this)) {}
 };
 
 } // namespace caelestia::config

--- a/utils/SysInfo.qml
+++ b/utils/SysInfo.qml
@@ -58,11 +58,11 @@ Singleton {
             root.osIdLike = fd("ID_LIKE").split(" ");
 
             const logo = Quickshell.iconPath(fd("LOGO"), true);
-            if (GlobalConfig.general.logo === "caelestia") {
+            if (GlobalConfig.general.logo.path === "caelestia") {
                 root.osLogo = Qt.resolvedUrl(`${Quickshell.shellDir}/assets/logo.svg`);
                 root.isDefaultLogo = true;
-            } else if (GlobalConfig.general.logo) {
-                root.osLogo = Quickshell.iconPath(GlobalConfig.general.logo, true) || "file://" + Paths.absolutePath(GlobalConfig.general.logo);
+            } else if (GlobalConfig.general.logo.path) {
+                root.osLogo = Quickshell.iconPath(GlobalConfig.general.logo.path, true) || "file://" + Paths.absolutePath(GlobalConfig.general.logo.path);
                 root.isDefaultLogo = false;
             } else if (logo) {
                 root.osLogo = logo;


### PR DESCRIPTION
Change `general.logo` config variable from string to an object that has both `path` and `size` properties