### PR TITLE
feat: custom GPU fragment shader for the visualiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,7 @@ For example, to automatically hide the bar on the monitor named `DP-1`:
             "autoHide": true,
             "blur": false,
             "enabled": false,
+            "renderer": "gpu",
             "rounding": 1,
             "spacing": 1
         },

--- a/modules/background/Visualiser.qml
+++ b/modules/background/Visualiser.qml
@@ -71,6 +71,8 @@ Item {
                     anchors.topMargin: Config.bar.position === "top" ? root.barExclusiveZone : Config.border.thickness
                     anchors.bottomMargin: Config.bar.position === "bottom" ? root.barExclusiveZone : (GlobalConfig.appearance.islands ? 0 : Config.border.thickness)
 
+                    visible: Config.background.visualiser.renderer === "cpu"
+
                     values: Audio.cava.values
                     primaryColor: Qt.alpha(Colours.palette.m3primary, 0.7)
                     secondaryColor: Qt.alpha(Colours.palette.m3inversePrimary, 0.7)
@@ -92,9 +94,68 @@ Item {
                     }
                 }
 
+                Canvas {
+                    id: dataCanvas
+
+                    visible: false
+                    width: Math.max(1, bars.displayValues.length)
+                    height: 1
+
+                    renderTarget: Canvas.FramebufferObject
+                    renderStrategy: Canvas.Cooperative
+
+                    onPaint: {
+                        var ctx = getContext("2d");
+                        var vals = bars.displayValues;
+                        var n = vals.length;
+                        for (let i = 0; i < n; i++) {
+                            const b = vals[i];
+                            const q = b <= 0 ? 0 : b >= 1 ? 65025 : Math.round(b * 65025);
+                            ctx.fillStyle = Qt.rgba((q >> 8) / 255, (q & 255) / 255, 0, 1);
+                            ctx.fillRect(i, 0, 1, 1);
+                        }
+                        dataTexSource.scheduleUpdate();
+                    }
+
+                    Component.onCompleted: requestPaint()
+                }
+
+                ShaderEffectSource {
+                    id: dataTexSource
+
+                    sourceItem: dataCanvas
+                    hideSource: true
+                    smooth: false
+                    live: false
+                }
+
+                ShaderEffect {
+                    id: gpuVisualiser
+
+                    visible: Config.background.visualiser.renderer !== "cpu"
+                    anchors.fill: bars
+
+                    property variant dataTex: dataTexSource
+                    property real itemWidth: width
+                    property real itemHeight: height
+                    property int barCount: bars.displayValues.length
+                    property real rounding: bars.rounding
+                    property real spacing: bars.spacing
+                    property color primaryColor: bars.primaryColor
+                    property color secondaryColor: bars.secondaryColor
+                    property real dpr: root.screen.devicePixelRatio
+
+                    fragmentShader: "qrc:/shaders/visualiser.frag.qsb"
+                }
+
                 FrameAnimation {
                     running: root.opacity > 0 && !bars.settled
-                    onTriggered: bars.advance(frameTime)
+                    onTriggered: {
+                        bars.advance(frameTime);
+                        if (Config.background.visualiser.renderer !== "cpu") {
+                            dataCanvas.requestPaint();
+                        }
+                    }
                 }
             }
         }

--- a/modules/nexus/pages/background/VisualiserPage.qml
+++ b/modules/nexus/pages/background/VisualiserPage.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import Caelestia.Config
+import qs.components.controls
 import qs.modules.nexus.common
 
 PageBase {
@@ -49,7 +50,6 @@ PageBase {
 
         ToggleRow {
             Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
-            last: true
             Layout.fillWidth: true
             text: qsTr("Blur background")
             subtext: qsTr("Blur the wallpaper behind the visualiser")
@@ -58,6 +58,25 @@ PageBase {
             checked: root.targetConfig.background.visualiser.blur
             onToggled: {
                 root.targetConfig.background.visualiser.blur = checked;
+                root.targetConfig.save();
+            }
+            enabled: root.targetConfig.background.visualiser.enabled
+        }
+
+        SelectRow {
+            Layout.topMargin: Tokens.spacing.extraSmall / 2 - parent.spacing
+            last: true
+            Layout.fillWidth: true
+            label: qsTr("Renderer")
+            configNode: root.targetConfig.background.visualiser
+            propertyName: "renderer"
+            menuItems: [
+                MenuItem { text: qsTr("GPU (Shader)") },
+                MenuItem { text: qsTr("CPU (QPainter)") }
+            ]
+            active: root.targetConfig.background.visualiser.renderer === "cpu" ? menuItems[1] : menuItems[0]
+            onSelected: item => {
+                root.targetConfig.background.visualiser.renderer = item === menuItems[1] ? "cpu" : "gpu";
                 root.targetConfig.save();
             }
             enabled: root.targetConfig.background.visualiser.enabled

--- a/plugin/src/Caelestia/Components/CMakeLists.txt
+++ b/plugin/src/Caelestia/Components/CMakeLists.txt
@@ -15,3 +15,12 @@ qml_module(caelestia-components
     DEPENDENCIES
         Caelestia
 )
+
+qt_add_shaders(caelestia-components "component_shaders"
+    BATCHABLE OPTIMIZED NOHLSL NOMSL
+    GLSL "300es,330"
+    PREFIX "/"
+    FILES
+        shaders/visualiser.frag
+)
+

--- a/plugin/src/Caelestia/Components/shaders/visualiser.frag
+++ b/plugin/src/Caelestia/Components/shaders/visualiser.frag
@@ -1,0 +1,106 @@
+#version 440
+
+layout(location = 0) in vec2 qt_TexCoord0;
+layout(location = 0) out vec4 fragColor;
+
+layout(binding = 1) uniform sampler2D dataTex;
+
+layout(std140, binding = 0) uniform buf {
+    mat4 qt_Matrix;
+    float qt_Opacity;
+    float itemWidth;
+    float itemHeight;
+    int barCount;
+    float rounding;
+    float spacing;
+    float dpr;
+    vec4 primaryColor;
+    vec4 secondaryColor;
+};
+
+float sampleBar(int i) {
+    if (barCount <= 0) return 0.0;
+
+    int ci = clamp(i, 0, barCount - 1);
+    float u = (float(ci) + 0.5) / float(barCount);
+    vec2 t = texture(dataTex, vec2(u, 0.5)).rg;
+    return clamp(t.x * (256.0 / 255.0) + t.y * (1.0 / 255.0), 0.0, 1.0);
+}
+
+void main() {
+    if (barCount <= 0 || itemWidth <= 0.0 || itemHeight <= 0.0) {
+        fragColor = vec4(0.0);
+        return;
+    }
+
+    float px = qt_TexCoord0.x * itemWidth;
+    float py = qt_TexCoord0.y * itemHeight;
+
+    float sideWidth = itemWidth * 0.4;
+    float slotWidth = sideWidth / float(barCount);
+    float barWidth = slotWidth - spacing;
+
+    if (barWidth <= 0.0) {
+        fragColor = vec4(0.0);
+        return;
+    }
+
+    bool isLeft = (px < sideWidth);
+    bool isRight = (px >= itemWidth * 0.6 && px <= itemWidth);
+
+    if (!isLeft && !isRight) {
+        fragColor = vec4(0.0);
+        return;
+    }
+
+    float sideOffset = isRight ? (itemWidth * 0.6) : 0.0;
+    float localX = px - sideOffset;
+
+    int i = int(floor(localX / slotWidth));
+    i = clamp(i, 0, barCount - 1);
+
+    int valueIndex = isRight ? i : (barCount - 1 - i);
+    float value = clamp(sampleBar(valueIndex), 0.0, 1.0);
+
+    float maxBarHeight = itemHeight * 0.4;
+    float barHeight = value * maxBarHeight;
+
+    if (barHeight <= 0.0) {
+        fragColor = vec4(0.0);
+        return;
+    }
+
+    float barLeft = sideOffset + float(i) * slotWidth;
+    float barTop = itemHeight - barHeight;
+    float barBottom = itemHeight;
+
+    float halfW = barWidth * 0.5;
+    float cx = barLeft + halfW;
+
+    float r = min(min(rounding, halfW), barHeight);
+
+    vec2 p = vec2(abs(px - cx), py);
+
+    float qx = p.x - halfW;
+    float qyTop = barTop - p.y;
+    float qyBot = p.y - barBottom;
+
+    float dist = max(qx, max(qyTop, qyBot));
+
+    if (r > 0.0 && p.x > (halfW - r) && p.y < (barTop + r)) {
+        vec2 cornerCenter = vec2(halfW - r, barTop + r);
+        dist = length(p - cornerCenter) - r;
+    }
+
+    float alpha = clamp(0.5 - dist * dpr, 0.0, 1.0);
+
+    if (alpha <= 0.0) {
+        fragColor = vec4(0.0);
+        return;
+    }
+
+    float gradT = clamp((py - (itemHeight - maxBarHeight)) / maxBarHeight, 0.0, 1.0);
+    vec4 col = mix(primaryColor, secondaryColor, gradT);
+
+    fragColor = col * alpha * qt_Opacity;
+}

--- a/plugin/src/Caelestia/Components/visualiserbars.cpp
+++ b/plugin/src/Caelestia/Components/visualiserbars.cpp
@@ -37,7 +37,10 @@ void VisualiserBars::advance(qreal dt) {
         }
     }
 
-    update();
+    emit displayValuesChanged();
+    if (isVisible()) {
+        update();
+    }
 
     if (allSettled && !m_settled) {
         m_settled = true;
@@ -118,11 +121,16 @@ QVector<double> VisualiserBars::values() const {
     return m_targetValues;
 }
 
+QVector<double> VisualiserBars::displayValues() const {
+    return m_displayValues;
+}
+
 void VisualiserBars::setValues(const QVector<double>& values) {
     m_targetValues = values;
 
     if (m_displayValues.size() != values.size()) {
         m_displayValues.resize(values.size(), 0.0);
+        emit displayValuesChanged();
     }
 
     if (m_settled) {

--- a/plugin/src/Caelestia/Components/visualiserbars.hpp
+++ b/plugin/src/Caelestia/Components/visualiserbars.hpp
@@ -13,6 +13,7 @@ class VisualiserBars : public QQuickPaintedItem {
     QML_ELEMENT
 
     Q_PROPERTY(QVector<double> values READ values WRITE setValues NOTIFY valuesChanged)
+    Q_PROPERTY(QVector<double> displayValues READ displayValues NOTIFY displayValuesChanged)
     Q_PROPERTY(QColor primaryColor READ primaryColor WRITE setPrimaryColor NOTIFY primaryColorChanged)
     Q_PROPERTY(QColor secondaryColor READ secondaryColor WRITE setSecondaryColor NOTIFY secondaryColorChanged)
     Q_PROPERTY(qreal rounding READ rounding WRITE setRounding NOTIFY roundingChanged)
@@ -29,6 +30,8 @@ public:
 
     [[nodiscard]] QVector<double> values() const;
     void setValues(const QVector<double>& values);
+
+    [[nodiscard]] QVector<double> displayValues() const;
 
     [[nodiscard]] QColor primaryColor() const;
     void setPrimaryColor(const QColor& color);
@@ -49,6 +52,7 @@ public:
 
 signals:
     void valuesChanged();
+    void displayValuesChanged();
     void primaryColorChanged();
     void secondaryColorChanged();
     void roundingChanged();

--- a/plugin/src/Caelestia/Config/backgroundconfig.hpp
+++ b/plugin/src/Caelestia/Config/backgroundconfig.hpp
@@ -42,6 +42,7 @@ class BackgroundVisualiser : public settings::ObjectNode {
     CONFIG_PROPERTY(bool, enabled, false)
     CONFIG_PROPERTY(bool, autoHide, true)
     CONFIG_PROPERTY(bool, blur, false)
+    CONFIG_PROPERTY(QString, renderer, QStringLiteral("gpu"))
     CONFIG_PROPERTY(qreal, rounding, 1)
     CONFIG_PROPERTY(qreal, spacing, 1)
 };


### PR DESCRIPTION
- Added a custom GPU fragment shader for the visualiser.
- I Kept the old QPainter CPU based implementation.
- Made the new one default and can choose which to use.

Since it now frees up the GUI thread it should make the WHOLE shell smoother when visualiser is on now :D

<img width="1918" height="1077" alt="image" src="https://github.com/user-attachments/assets/ffee2fcf-66a1-4462-b89f-555f46e473b2" />

<img width="1513" height="809" alt="image" src="https://github.com/user-attachments/assets/2cff375c-7507-4012-a862-fa5c2cced8c6" />
