### PR TITLE
fix: build against upstream's strict string cast flags

### DIFF
--- a/plugin/src/Caelestia/Config/sessionconfig.cpp
+++ b/plugin/src/Caelestia/Config/sessionconfig.cpp
@@ -143,9 +143,9 @@ void SessionConfig::refreshButtons() {
 QVariantList SessionConfig::buttons() const {
     QVariantList result;
 
-    const auto* icons = icons();
-    const auto* commands = commands();
-    if (!icons || !commands)
+    const auto* iconsNode = icons();
+    const auto* commandsNode = commands();
+    if (!iconsNode || !commandsNode)
         return result;
 
     static const QStringList defaultKeys = {
@@ -159,13 +159,13 @@ QVariantList SessionConfig::buttons() const {
     QSet<QString> seen;
 
     // Custom keys first (in captured order), then the standard four.
-    for (const auto& key : icons->customIconKeys()) {
+    for (const auto& key : iconsNode->customIconKeys()) {
         if (!seen.contains(key)) {
             seen.insert(key);
             orderedKeys.append(key);
         }
     }
-    for (const auto& key : commands->customCommandKeys()) {
+    for (const auto& key : commandsNode->customCommandKeys()) {
         if (!seen.contains(key)) {
             seen.insert(key);
             orderedKeys.append(key);
@@ -183,20 +183,20 @@ QVariantList SessionConfig::buttons() const {
         btn.insert(u"key"_s, key);
 
         QString icon = key;
-        if (icons->customIcons().contains(key)) {
-            icon = icons->customIcons().value(key);
+        if (iconsNode->customIcons().contains(key)) {
+            icon = iconsNode->customIcons().value(key);
         } else {
-            const QVariant iconProp = icons->value(key);
+            const QVariant iconProp = iconsNode->value(key);
             if (iconProp.isValid() && iconProp.userType() == QMetaType::QString)
                 icon = iconProp.toString();
         }
         btn.insert(u"icon"_s, icon);
 
         QStringList command;
-        if (commands->customCommands().contains(key)) {
-            command = commands->customCommands().value(key);
+        if (commandsNode->customCommands().contains(key)) {
+            command = commandsNode->customCommands().value(key);
         } else {
-            const QVariant cmdProp = commands->value(key);
+            const QVariant cmdProp = commandsNode->value(key);
             if (cmdProp.isValid() && cmdProp.userType() == QMetaType::QStringList)
                 command = cmdProp.toStringList();
             else
@@ -213,21 +213,21 @@ QVariantList SessionConfig::buttons() const {
 QVariantList SessionConfig::customButtons() const {
     QVariantList result;
 
-    const auto* icons = icons();
-    const auto* commands = commands();
-    if (!icons || !commands)
+    const auto* iconsNode = icons();
+    const auto* commandsNode = commands();
+    if (!iconsNode || !commandsNode)
         return result;
 
     QStringList orderedKeys;
     QSet<QString> seen;
 
-    for (const auto& key : icons->customIconKeys()) {
+    for (const auto& key : iconsNode->customIconKeys()) {
         if (!knownSessionKeys().contains(key) && !seen.contains(key)) {
             seen.insert(key);
             orderedKeys.append(key);
         }
     }
-    for (const auto& key : commands->customCommandKeys()) {
+    for (const auto& key : commandsNode->customCommandKeys()) {
         if (!knownSessionKeys().contains(key) && !seen.contains(key)) {
             seen.insert(key);
             orderedKeys.append(key);
@@ -239,13 +239,13 @@ QVariantList SessionConfig::customButtons() const {
         btn.insert(u"key"_s, key);
 
         QString icon = key;
-        if (icons->customIcons().contains(key))
-            icon = icons->customIcons().value(key);
+        if (iconsNode->customIcons().contains(key))
+            icon = iconsNode->customIcons().value(key);
         btn.insert(u"icon"_s, icon);
 
         QStringList command;
-        if (commands->customCommands().contains(key)) {
-            command = commands->customCommands().value(key);
+        if (commandsNode->customCommands().contains(key)) {
+            command = commandsNode->customCommands().value(key);
         } else {
             command = QStringList { key };
         }

--- a/plugin/src/Caelestia/Images/iutils.cpp
+++ b/plugin/src/Caelestia/Images/iutils.cpp
@@ -77,7 +77,7 @@ bool IUtils::isVideo(const QString& path) {
         return false;
     
     const QString suffix = QFileInfo(path).suffix().toLower();
-    static const QStringList videoExtensions = { "mp4", "webm", "mkv", "avi", "mov", "wmv", "flv" };
+    static const QStringList videoExtensions = { u"mp4"_s, u"webm"_s, u"mkv"_s, u"avi"_s, u"mov"_s, u"wmv"_s, u"flv"_s };
     return videoExtensions.contains(suffix);
 }
 

--- a/plugin/src/Caelestia/Services/QuickShare/QuickShareBle.cpp
+++ b/plugin/src/Caelestia/Services/QuickShare/QuickShareBle.cpp
@@ -6,6 +6,8 @@
 #include <QDBusPendingReply>
 #include <QDebug>
 
+using Qt::StringLiterals::operator""_s;
+
 // --------------------------------------------------------------------------------
 // QuickShareBleAdvertisementAdaptor
 // --------------------------------------------------------------------------------
@@ -22,12 +24,12 @@ QVariantMap QuickShareBleAdvertisementAdaptor::serviceData() const {
         (char)191, 45, 91, (char)160, (char)225, (char)216, 117, 36, (char)202, 0
     };
     QByteArray data(rawData, 24);
-    map.insert("0000fe2c-0000-1000-8000-00805f9b34fb", QVariant::fromValue(data));
+    map.insert(u"0000fe2c-0000-1000-8000-00805f9b34fb"_s, QVariant::fromValue(data));
     return map;
 }
 
 void QuickShareBleAdvertisementAdaptor::Release() {
-    qDebug() << "QuickShareBleAdvertisement released by BlueZ";
+    qDebug() << u"QuickShareBleAdvertisement released by BlueZ"_s;
 }
 
 // --------------------------------------------------------------------------------
@@ -35,7 +37,7 @@ void QuickShareBleAdvertisementAdaptor::Release() {
 // --------------------------------------------------------------------------------
 
 QuickShareBleAdvertiser::QuickShareBleAdvertiser(QObject* parent)
-    : QObject(parent), m_objectPath("/org/caelestia/QuickShareBleAdvertisement"), m_isAdvertising(false)
+    : QObject(parent), m_objectPath(u"/org/caelestia/QuickShareBleAdvertisement"_s), m_isAdvertising(false)
 {
     new QuickShareBleAdvertisementAdaptor(this);
     QDBusConnection::systemBus().registerObject(m_objectPath, this);
@@ -50,7 +52,7 @@ void QuickShareBleAdvertiser::startAdvertising() {
     if (m_isAdvertising) return;
 
     QDBusMessage msg = QDBusMessage::createMethodCall(
-        "org.bluez", "/", "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+        u"org.bluez"_s, u"/"_s, u"org.freedesktop.DBus.ObjectManager"_s, u"GetManagedObjects"_s);
     
     QDBusConnection::systemBus().callWithCallback(msg, this, SLOT(onGetManagedObjectsFinished(QDBusMessage)));
 }
@@ -59,7 +61,7 @@ void QuickShareBleAdvertiser::stopAdvertising() {
     if (!m_isAdvertising || m_adapterPath.isEmpty()) return;
 
     QDBusMessage msg = QDBusMessage::createMethodCall(
-        "org.bluez", m_adapterPath, "org.bluez.LEAdvertisingManager1", "UnregisterAdvertisement");
+        u"org.bluez"_s, m_adapterPath, u"org.bluez.LEAdvertisingManager1"_s, u"UnregisterAdvertisement"_s);
     msg << QVariant::fromValue(QDBusObjectPath(m_objectPath));
     QDBusConnection::systemBus().call(msg); // sync call is fine here for cleanup
     m_isAdvertising = false;
@@ -67,7 +69,7 @@ void QuickShareBleAdvertiser::stopAdvertising() {
 
 void QuickShareBleAdvertiser::onGetManagedObjectsFinished(const QDBusMessage& reply) {
     if (reply.type() == QDBusMessage::ErrorMessage) {
-        qWarning() << "Failed to get managed objects:" << reply.errorMessage();
+        qWarning() << u"Failed to get managed objects:"_s << reply.errorMessage();
         return;
     }
 
@@ -76,19 +78,19 @@ void QuickShareBleAdvertiser::onGetManagedObjectsFinished(const QDBusMessage& re
     arg >> objects;
 
     for (auto it = objects.constBegin(); it != objects.constEnd(); ++it) {
-        if (it.value().contains("org.bluez.LEAdvertisingManager1")) {
+        if (it.value().contains(u"org.bluez.LEAdvertisingManager1"_s)) {
             m_adapterPath = it.key().path();
             break;
         }
     }
 
     if (m_adapterPath.isEmpty()) {
-        qWarning() << "No adapter with LEAdvertisingManager1 found.";
+        qWarning() << u"No adapter with LEAdvertisingManager1 found."_s;
         return;
     }
 
     QDBusMessage msg = QDBusMessage::createMethodCall(
-        "org.bluez", m_adapterPath, "org.bluez.LEAdvertisingManager1", "RegisterAdvertisement");
+        u"org.bluez"_s, m_adapterPath, u"org.bluez.LEAdvertisingManager1"_s, u"RegisterAdvertisement"_s);
     msg << QVariant::fromValue(QDBusObjectPath(m_objectPath));
     msg << QVariantMap(); // empty dict
 
@@ -97,9 +99,9 @@ void QuickShareBleAdvertiser::onGetManagedObjectsFinished(const QDBusMessage& re
 
 void QuickShareBleAdvertiser::onRegisterAdvertisementFinished(const QDBusMessage& reply) {
     if (reply.type() == QDBusMessage::ErrorMessage) {
-        qWarning() << "Failed to register advertisement:" << reply.errorMessage();
+        qWarning() << u"Failed to register advertisement:"_s << reply.errorMessage();
     } else {
-        qDebug() << "Successfully registered BLE advertisement.";
+        qDebug() << u"Successfully registered BLE advertisement."_s;
         m_isAdvertising = true;
     }
 }
@@ -112,7 +114,7 @@ QuickShareBleScanner::QuickShareBleScanner(QObject* parent)
     : QObject(parent), m_isScanning(false)
 {
     QDBusConnection::systemBus().connect(
-        "org.bluez", "/", "org.freedesktop.DBus.ObjectManager", "InterfacesAdded",
+        u"org.bluez"_s, u"/"_s, u"org.freedesktop.DBus.ObjectManager"_s, u"InterfacesAdded"_s,
         this, SLOT(onInterfacesAdded(QDBusObjectPath, QMap<QString, QVariantMap>)));
 }
 
@@ -124,7 +126,7 @@ void QuickShareBleScanner::startScanning() {
     if (m_isScanning) return;
 
     QDBusMessage msg = QDBusMessage::createMethodCall(
-        "org.bluez", "/", "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");
+        u"org.bluez"_s, u"/"_s, u"org.freedesktop.DBus.ObjectManager"_s, u"GetManagedObjects"_s);
     
     QDBusConnection::systemBus().callWithCallback(msg, this, SLOT(onGetManagedObjectsFinished(QDBusMessage)));
 }
@@ -133,14 +135,14 @@ void QuickShareBleScanner::stopScanning() {
     if (!m_isScanning || m_adapterPath.isEmpty()) return;
 
     QDBusMessage msg = QDBusMessage::createMethodCall(
-        "org.bluez", m_adapterPath, "org.bluez.Adapter1", "StopDiscovery");
+        u"org.bluez"_s, m_adapterPath, u"org.bluez.Adapter1"_s, u"StopDiscovery"_s);
     QDBusConnection::systemBus().call(msg);
     m_isScanning = false;
 }
 
 void QuickShareBleScanner::onGetManagedObjectsFinished(const QDBusMessage& reply) {
     if (reply.type() == QDBusMessage::ErrorMessage) {
-        qWarning() << "Failed to get managed objects for scanner:" << reply.errorMessage();
+        qWarning() << u"Failed to get managed objects for scanner:"_s << reply.errorMessage();
         return;
     }
 
@@ -149,72 +151,72 @@ void QuickShareBleScanner::onGetManagedObjectsFinished(const QDBusMessage& reply
     arg >> objects;
 
     for (auto it = objects.constBegin(); it != objects.constEnd(); ++it) {
-        if (it.value().contains("org.bluez.Adapter1")) {
+        if (it.value().contains(u"org.bluez.Adapter1"_s)) {
             m_adapterPath = it.key().path();
             break;
         }
     }
 
     if (m_adapterPath.isEmpty()) {
-        qWarning() << "No adapter with org.bluez.Adapter1 found.";
+        qWarning() << u"No adapter with org.bluez.Adapter1 found."_s;
         return;
     }
 
     QDBusMessage filterMsg = QDBusMessage::createMethodCall(
-        "org.bluez", m_adapterPath, "org.bluez.Adapter1", "SetDiscoveryFilter");
+        u"org.bluez"_s, m_adapterPath, u"org.bluez.Adapter1"_s, u"SetDiscoveryFilter"_s);
     QVariantMap filter;
-    filter.insert("UUIDs", QStringList{"0000fe2c-0000-1000-8000-00805f9b34fb"});
+    filter.insert(u"UUIDs"_s, QStringList{u"0000fe2c-0000-1000-8000-00805f9b34fb"_s});
     filterMsg << filter;
     QDBusConnection::systemBus().callWithCallback(filterMsg, this, SLOT(onSetDiscoveryFilterFinished(QDBusMessage)));
 }
 
 void QuickShareBleScanner::onSetDiscoveryFilterFinished(const QDBusMessage& reply) {
     if (reply.type() == QDBusMessage::ErrorMessage) {
-        qWarning() << "Failed to set discovery filter:" << reply.errorMessage();
+        qWarning() << u"Failed to set discovery filter:"_s << reply.errorMessage();
     }
 
     QDBusMessage startMsg = QDBusMessage::createMethodCall(
-        "org.bluez", m_adapterPath, "org.bluez.Adapter1", "StartDiscovery");
+        u"org.bluez"_s, m_adapterPath, u"org.bluez.Adapter1"_s, u"StartDiscovery"_s);
     QDBusConnection::systemBus().callWithCallback(startMsg, this, SLOT(onStartDiscoveryFinished(QDBusMessage)));
 }
 
 void QuickShareBleScanner::onStartDiscoveryFinished(const QDBusMessage& reply) {
     if (reply.type() == QDBusMessage::ErrorMessage) {
-        qWarning() << "Failed to start discovery:" << reply.errorMessage();
+        qWarning() << u"Failed to start discovery:"_s << reply.errorMessage();
     } else {
-        qDebug() << "Started BLE discovery.";
+        qDebug() << u"Started BLE discovery."_s;
         m_isScanning = true;
     }
 }
 
 void QuickShareBleScanner::onInterfacesAdded(const QDBusObjectPath& objectPath, const QMap<QString, QVariantMap>& interfacesAndProperties) {
-    if (interfacesAndProperties.contains("org.bluez.Device1")) {
-        QVariantMap props = interfacesAndProperties.value("org.bluez.Device1");
+    if (interfacesAndProperties.contains(u"org.bluez.Device1"_s)) {
+        QVariantMap props = interfacesAndProperties.value(u"org.bluez.Device1"_s);
         checkDeviceProperties(props);
         
         QDBusConnection::systemBus().connect(
-            "org.bluez", objectPath.path(), "org.freedesktop.DBus.Properties", "PropertiesChanged",
+            u"org.bluez"_s, objectPath.path(), u"org.freedesktop.DBus.Properties"_s, u"PropertiesChanged"_s,
             this, SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
     }
 }
 
 void QuickShareBleScanner::onPropertiesChanged(const QString& interface, const QVariantMap& changedProperties, const QStringList& invalidatedProperties) {
     Q_UNUSED(invalidatedProperties);
-    if (interface == "org.bluez.Device1") {
+    if (interface == u"org.bluez.Device1"_s) {
         checkDeviceProperties(changedProperties);
     }
 }
 
 void QuickShareBleScanner::checkDeviceProperties(const QVariantMap& props) {
-    if (props.contains("ServiceData")) {
-        const QDBusArgument arg = props.value("ServiceData").value<QDBusArgument>();
+    if (props.contains(u"ServiceData"_s)) {
+        const QDBusArgument arg = props.value(u"ServiceData"_s).value<QDBusArgument>();
         QMap<QString, QVariant> serviceData;
         arg >> serviceData;
         
         // Sometimes QDBusArgument converts to QMap<QString, QByteArray> or QVariant
-        if (serviceData.contains("0000fe2c-0000-1000-8000-00805f9b34fb")) {
+        if (serviceData.contains(u"0000fe2c-0000-1000-8000-00805f9b34fb"_s)) {
             QByteArray data;
-            QVariant val = serviceData.value("0000fe2c-0000-1000-8000-00805f9b34fb");
+            QVariant val = serviceData.value(u"0000fe2c-0000-1000-8000-00805f9b34fb"_s);
             if (val.userType() == QMetaType::QByteArray) {
                 data = val.toByteArray();
             } else if (val.canConvert<QDBusArgument>()) {
@@ -226,9 +228,9 @@ void QuickShareBleScanner::checkDeviceProperties(const QVariantMap& props) {
                 QDateTime now = QDateTime::currentDateTime();
                 if (!m_lastEmit.isValid() || m_lastEmit.msecsTo(now) > 10000) {
                     m_lastEmit = now;
-                    QString address = props.value("Address").toString();
+                    QString address = props.value(u"Address"_s).toString();
                     emit deviceFound(address, data);
-                    qDebug() << "QuickShareBleScanner found device:" << address;
+                    qDebug() << u"QuickShareBleScanner found device:"_s << address;
                 }
             }
         }

--- a/plugin/src/Caelestia/Services/QuickShare/QuickShareBle.hpp
+++ b/plugin/src/Caelestia/Services/QuickShare/QuickShareBle.hpp
@@ -9,6 +9,8 @@
 #include <QDBusObjectPath>
 #include <QDateTime>
 
+using Qt::StringLiterals::operator""_s;
+
 class QuickShareBleAdvertisementAdaptor : public QDBusAbstractAdaptor {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.bluez.LEAdvertisement1")
@@ -18,8 +20,8 @@ class QuickShareBleAdvertisementAdaptor : public QDBusAbstractAdaptor {
 
 public:
     explicit QuickShareBleAdvertisementAdaptor(QObject *parent);
-    QString type() const { return "broadcast"; }
-    QStringList serviceUUIDs() const { return {"0000fe2c-0000-1000-8000-00805f9b34fb"}; }
+    QString type() const { return u"broadcast"_s; }
+    QStringList serviceUUIDs() const { return {u"0000fe2c-0000-1000-8000-00805f9b34fb"_s}; }
     QVariantMap serviceData() const;
 
 public slots:

--- a/plugin/src/Caelestia/Services/QuickShare/QuickShareConnection.cpp
+++ b/plugin/src/Caelestia/Services/QuickShare/QuickShareConnection.cpp
@@ -17,6 +17,8 @@
 #include "device_to_device_messages.pb.h"
 #include "wire_format.pb.h"
 
+using Qt::StringLiterals::operator""_s;
+
 namespace caelestia::services {
 
 static void writeLengthPrefixed(QTcpSocket* socket, const QByteArray& data) {
@@ -61,7 +63,7 @@ QuickShareConnection::QuickShareConnection(const QString& host, int port, QObjec
         auto* req = v1->mutable_connection_request();
         req->set_endpoint_id("ABCD");
         QString hostname = QSysInfo::machineHostName();
-        if (hostname.isEmpty()) hostname = "CaelestiaClient";
+        if (hostname.isEmpty()) hostname = u"CaelestiaClient"_s;
         req->set_endpoint_name(hostname.toStdString());
 
         QByteArray endpointInfo;
@@ -70,7 +72,7 @@ QuickShareConnection::QuickShareConnection(const QString& host, int port, QObjec
             endpointInfo.append(static_cast<char>(QRandomGenerator::global()->generate()));
         }
         QString deviceName = QSysInfo::machineHostName();
-        if (deviceName.isEmpty()) deviceName = "CaelestiaClient";
+        if (deviceName.isEmpty()) deviceName = u"CaelestiaClient"_s;
         QByteArray nameBytes = deviceName.toUtf8();
         if (nameBytes.length() > 255) nameBytes.truncate(255);
         endpointInfo.append(static_cast<char>(nameBytes.length()));
@@ -101,7 +103,7 @@ void QuickShareConnection::sendFile(const QString& filePath) {
     
     QFileInfo fileInfo(filePath);
     if (!fileInfo.exists()) {
-        qWarning() << "QuickShareConnection: File to send does not exist:" << filePath;
+        qWarning() << u"QuickShareConnection: File to send does not exist:"_s << filePath;
         emit transferFinished(false);
         return;
     }
@@ -121,15 +123,15 @@ void QuickShareConnection::sendFile(const QString& filePath) {
     QMimeDatabase db;
     QMimeType mimeType = db.mimeTypeForFile(fileInfo);
     QString mimeString = mimeType.name();
-    if (mimeString.isEmpty()) mimeString = "application/octet-stream";
+    if (mimeString.isEmpty()) mimeString = u"application/octet-stream"_s;
     
     fileMeta->set_mime_type(mimeString.toStdString());
     
-    if (mimeString.startsWith("image/")) {
+    if (mimeString.startsWith(u"image/"_s)) {
         fileMeta->set_type(sharing::nearby::FileMetadata::IMAGE);
-    } else if (mimeString.startsWith("video/")) {
+    } else if (mimeString.startsWith(u"video/"_s)) {
         fileMeta->set_type(sharing::nearby::FileMetadata::VIDEO);
-    } else if (mimeString.startsWith("audio/")) {
+    } else if (mimeString.startsWith(u"audio/"_s)) {
         fileMeta->set_type(sharing::nearby::FileMetadata::AUDIO);
     } else {
         fileMeta->set_type(sharing::nearby::FileMetadata::UNKNOWN);
@@ -329,7 +331,7 @@ void QuickShareConnection::onReadyRead() {
 void QuickShareConnection::handleOfflineFrame(const QByteArray& data) {
     location::nearby::connections::OfflineFrame frame;
     if (!frame.ParseFromArray(data.constData(), static_cast<int>(data.size()))) {
-        qWarning() << "QuickShareConnection: Failed to parse initial OfflineFrame";
+        qWarning() << u"QuickShareConnection: Failed to parse initial OfflineFrame"_s;
         return;
     }
     
@@ -363,7 +365,7 @@ void QuickShareConnection::handleUkey2(const QByteArray& data) {
             if (msg.message_type() == securegcm::Ukey2Message::CLIENT_INIT) {
                 QByteArray serverInit = m_crypto.processClientInit(data);
                 if (serverInit.isEmpty()) {
-                    qWarning() << "QuickShareConnection: m_crypto.processClientInit failed";
+                    qWarning() << u"QuickShareConnection: m_crypto.processClientInit failed"_s;
                 } else {
                     writeLengthPrefixed(m_socket, serverInit);
                 }
@@ -391,7 +393,7 @@ void QuickShareConnection::handleUkey2(const QByteArray& data) {
                 emit stateChanged(m_state);
             } else if (msg.message_type() == securegcm::Ukey2Message::CLIENT_FINISH) {
                 if (!m_crypto.processClientFinished(data)) {
-                    qWarning() << "QuickShareConnection: m_crypto.processClientFinished failed!";
+                    qWarning() << u"QuickShareConnection: m_crypto.processClientFinished failed!"_s;
                 } else {
                     m_state = PostHandshake;
                     emit stateChanged(m_state);
@@ -400,17 +402,17 @@ void QuickShareConnection::handleUkey2(const QByteArray& data) {
                 }
             }
         } else {
-            qWarning() << "QuickShareConnection: Failed to parse Ukey2Message!";
+            qWarning() << u"QuickShareConnection: Failed to parse Ukey2Message!"_s;
         }
     } else {
-        qWarning() << "QuickShareConnection: Received Ukey2 message but handshake is already complete!";
+        qWarning() << u"QuickShareConnection: Received Ukey2 message but handshake is already complete!"_s;
     }
 }
 
 void QuickShareConnection::handlePostHandshake(const QByteArray& data) {
     location::nearby::connections::OfflineFrame frame;
     if (!frame.ParseFromArray(data.constData(), static_cast<int>(data.size()))) {
-        qWarning() << "QuickShareConnection: Failed to parse plaintext CONNECTION_RESPONSE";
+        qWarning() << u"QuickShareConnection: Failed to parse plaintext CONNECTION_RESPONSE"_s;
         return;
     }
 
@@ -512,7 +514,7 @@ QByteArray QuickShareConnection::wrapInSecureMessage(const QByteArray& offlineFr
 QByteArray QuickShareConnection::unwrapSecureMessage(const QByteArray& secureMessageData) {
     securemessage::SecureMessage secMsg;
     if (!secMsg.ParseFromArray(secureMessageData.constData(), static_cast<int>(secureMessageData.size()))) {
-        qWarning() << "QuickShareConnection: Failed to parse SecureMessage";
+        qWarning() << u"QuickShareConnection: Failed to parse SecureMessage"_s;
         return QByteArray();
     }
 
@@ -527,13 +529,13 @@ QByteArray QuickShareConnection::unwrapSecureMessage(const QByteArray& secureMes
 
     if (static_cast<int>(hmacLen) != secMsg.signature().size() ||
         memcmp(hmacResult, secMsg.signature().data(), hmacLen) != 0) {
-        qWarning() << "QuickShareConnection: HMAC verification failed";
+        qWarning() << u"QuickShareConnection: HMAC verification failed"_s;
         return QByteArray();
     }
 
     securemessage::HeaderAndBody headerAndBody;
     if (!headerAndBody.ParseFromArray(headerAndBodyBytes.constData(), static_cast<int>(headerAndBodyBytes.size()))) {
-        qWarning() << "QuickShareConnection: Failed to parse HeaderAndBody";
+        qWarning() << u"QuickShareConnection: Failed to parse HeaderAndBody"_s;
         return QByteArray();
     }
 
@@ -557,7 +559,7 @@ QByteArray QuickShareConnection::unwrapSecureMessage(const QByteArray& secureMes
 
     securegcm::DeviceToDeviceMessage d2dMsg;
     if (!d2dMsg.ParseFromArray(plaintext.constData(), static_cast<int>(plaintext.size()))) {
-        qWarning() << "QuickShareConnection: Failed to parse DeviceToDeviceMessage";
+        qWarning() << u"QuickShareConnection: Failed to parse DeviceToDeviceMessage"_s;
         return QByteArray();
     }
 
@@ -567,13 +569,13 @@ QByteArray QuickShareConnection::unwrapSecureMessage(const QByteArray& secureMes
 void QuickShareConnection::handleEncryptedFrame(const QByteArray& data) {
     QByteArray plaintext = unwrapSecureMessage(data);
     if (plaintext.isEmpty()) {
-        qWarning() << "QuickShareConnection: Failed to unwrap encrypted frame";
+        qWarning() << u"QuickShareConnection: Failed to unwrap encrypted frame"_s;
         return;
     }
 
     location::nearby::connections::OfflineFrame offlineFrame;
     if (!offlineFrame.ParseFromArray(plaintext.constData(), static_cast<int>(plaintext.size()))) {
-        qWarning() << "QuickShareConnection: Failed to parse OfflineFrame from decrypted data";
+        qWarning() << u"QuickShareConnection: Failed to parse OfflineFrame from decrypted data"_s;
         return;
     }
 
@@ -617,13 +619,13 @@ void QuickShareConnection::handlePayloadTransfer(const QByteArray& plaintext) {
         emit transferProgress(m_fileBuffer.size(), m_incomingFileSize);
 
         if ((payloadChunk.flags() & 1) == 1) {
-            QString savePath = QDir::homePath() + "/Downloads/" + m_incomingFileName;
+            QString savePath = QDir::homePath() + u"/Downloads/"_s + m_incomingFileName;
             QFile file(savePath);
             if (file.open(QIODevice::WriteOnly)) {
                 file.write(m_fileBuffer);
                 file.close();
             } else {
-                qWarning() << "QuickShareConnection: Failed to save file to" << savePath;
+                qWarning() << u"QuickShareConnection: Failed to save file to"_s << savePath;
             }
             m_fileTransferActive = false;
             m_fileBuffer.clear();
@@ -652,7 +654,7 @@ void QuickShareConnection::handlePayloadTransfer(const QByteArray& plaintext) {
             QByteArray buf = m_payloadBuffers[payloadId];
             QString hex;
             for (int i = 0; i < qMin(buf.size(), 64); ++i)
-                hex += QString("%1 ").arg(static_cast<uchar>(buf[i]), 2, 16, QChar('0'));
+                hex += QString(u"%1 "_s).arg(static_cast<uchar>(buf[i]), 2, 16, QLatin1Char('0'));
 
             sharing::nearby::Frame frame;
             if (frame.ParseFromArray(m_payloadBuffers[payloadId].constData(), m_payloadBuffers[payloadId].size())) {
@@ -762,7 +764,7 @@ void QuickShareConnection::handlePayloadTransfer(const QByteArray& plaintext) {
                                     
                                     emit transferFinished(true);
                                 } else {
-                                    qWarning() << "QuickShareConnection: Failed to open file to send!";
+                                    qWarning() << u"QuickShareConnection: Failed to open file to send!"_s;
                                     emit transferFinished(false);
                                 }
                             } else {
@@ -791,7 +793,7 @@ void QuickShareConnection::onDisconnected() {
 
 void QuickShareConnection::onError(QAbstractSocket::SocketError socketError) {
     Q_UNUSED(socketError);
-    qWarning() << "QuickShareConnection error:" << m_socket->errorString();
+    qWarning() << u"QuickShareConnection error:"_s << m_socket->errorString();
     emit transferFinished(false);
 }
 

--- a/plugin/src/Caelestia/Services/QuickShare/QuickShareCrypto.cpp
+++ b/plugin/src/Caelestia/Services/QuickShare/QuickShareCrypto.cpp
@@ -11,6 +11,8 @@
 #include "ukey.pb.h"
 #include "securemessage.pb.h"
 
+using Qt::StringLiterals::operator""_s;
+
 namespace caelestia::services {
 
 static QByteArray hkdfInternal(const EVP_MD* md, const QByteArray& salt, const QByteArray& ikm, const QByteArray& info, size_t outLen) {
@@ -148,7 +150,7 @@ QString QuickShareCrypto::pinCode() const {
         multiplier = (multiplier * kHashBaseMultiplier) % kHashModulo;
     }
 
-    return QString("%1").arg(abs(hash), 4, 10, QChar('0'));
+    return QString(u"%1"_s).arg(abs(hash), 4, 10, QLatin1Char('0'));
 }
 
 QByteArray QuickShareCrypto::extractSharedSecret(EVP_PKEY* peerKey) {
@@ -311,7 +313,7 @@ QByteArray QuickShareCrypto::generateClientInit() {
     {
         QString hex;
         for (int i = 0; i < SHA512_DIGEST_LENGTH; ++i)
-            hex += QString("%1").arg(hash[i], 2, 16, QChar('0'));
+            hex += QString(u"%1"_s).arg(hash[i], 2, 16, QLatin1Char('0'));
     }
 
     securegcm::Ukey2ClientInit clientInit;

--- a/plugin/src/Caelestia/Services/QuickShare/QuickShareDiscovery.cpp
+++ b/plugin/src/Caelestia/Services/QuickShare/QuickShareDiscovery.cpp
@@ -8,6 +8,8 @@
 #include <QHostInfo>
 #include <QRandomGenerator>
 
+using Qt::StringLiterals::operator""_s;
+
 namespace caelestia::services {
 
 QuickShareDiscovery::QuickShareDiscovery(QObject* parent)
@@ -26,48 +28,48 @@ bool QuickShareDiscovery::startDiscovery() {
     if (m_isDiscovering) return true;
 
     QDBusInterface avahiServer(
-        "org.freedesktop.Avahi",
-        "/",
-        "org.freedesktop.Avahi.Server",
+        u"org.freedesktop.Avahi"_s,
+        u"/"_s,
+        u"org.freedesktop.Avahi.Server"_s,
         QDBusConnection::systemBus());
 
     if (!avahiServer.isValid()) {
-        qWarning() << "QuickShareDiscovery: Failed to connect to Avahi server";
+        qWarning() << u"QuickShareDiscovery: Failed to connect to Avahi server"_s;
         return false;
     }
 
-    QDBusReply<QDBusObjectPath> browserPath = avahiServer.call("ServiceBrowserNew",
+    QDBusReply<QDBusObjectPath> browserPath = avahiServer.call(u"ServiceBrowserNew"_s,
         -1, // AVAHI_IF_UNSPEC
         -1, // AVAHI_PROTO_UNSPEC
-        "_FC9F5ED42C8A._tcp",
-        "local",
+        u"_FC9F5ED42C8A._tcp"_s,
+        u"local"_s,
         (uint)0); // flags
 
     if (!browserPath.isValid()) {
-        qWarning() << "QuickShareDiscovery: Failed to create ServiceBrowser:" << browserPath.error().message();
+        qWarning() << u"QuickShareDiscovery: Failed to create ServiceBrowser:"_s << browserPath.error().message();
         return false;
     }
 
     m_serverBrowser = new QDBusInterface(
-        "org.freedesktop.Avahi",
+        u"org.freedesktop.Avahi"_s,
         browserPath.value().path(),
-        "org.freedesktop.Avahi.ServiceBrowser",
+        u"org.freedesktop.Avahi.ServiceBrowser"_s,
         QDBusConnection::systemBus(),
         this);
 
     QDBusConnection::systemBus().connect(
-        "org.freedesktop.Avahi",
+        u"org.freedesktop.Avahi"_s,
         browserPath.value().path(),
-        "org.freedesktop.Avahi.ServiceBrowser",
-        "ItemNew",
+        u"org.freedesktop.Avahi.ServiceBrowser"_s,
+        u"ItemNew"_s,
         this,
         SLOT(onItemNew(int, int, const QString&, const QString&, const QString&, uint)));
 
     QDBusConnection::systemBus().connect(
-        "org.freedesktop.Avahi",
+        u"org.freedesktop.Avahi"_s,
         browserPath.value().path(),
-        "org.freedesktop.Avahi.ServiceBrowser",
-        "ItemRemove",
+        u"org.freedesktop.Avahi.ServiceBrowser"_s,
+        u"ItemRemove"_s,
         this,
         SLOT(onItemRemove(int, int, const QString&, const QString&, const QString&, uint)));
 
@@ -79,7 +81,7 @@ void QuickShareDiscovery::stopDiscovery() {
     if (!m_isDiscovering) return;
     
     if (m_serverBrowser) {
-        m_serverBrowser->call("Free");
+        m_serverBrowser->call(u"Free"_s);
         m_serverBrowser->deleteLater();
         m_serverBrowser = nullptr;
     }
@@ -93,20 +95,20 @@ bool QuickShareDiscovery::advertise(const QString& deviceName, int port) {
     if (m_isAdvertising) return true;
 
     QDBusInterface avahiServer(
-        "org.freedesktop.Avahi",
-        "/",
-        "org.freedesktop.Avahi.Server",
+        u"org.freedesktop.Avahi"_s,
+        u"/"_s,
+        u"org.freedesktop.Avahi.Server"_s,
         QDBusConnection::systemBus());
 
     if (!avahiServer.isValid()) return false;
 
-    QDBusReply<QDBusObjectPath> groupPath = avahiServer.call("EntryGroupNew");
+    QDBusReply<QDBusObjectPath> groupPath = avahiServer.call(u"EntryGroupNew"_s);
     if (!groupPath.isValid()) return false;
 
     m_entryGroup = new QDBusInterface(
-        "org.freedesktop.Avahi",
+        u"org.freedesktop.Avahi"_s,
         groupPath.value().path(),
-        "org.freedesktop.Avahi.EntryGroup",
+        u"org.freedesktop.Avahi.EntryGroup"_s,
         QDBusConnection::systemBus(),
         this);
 
@@ -143,27 +145,27 @@ bool QuickShareDiscovery::advertise(const QString& deviceName, int port) {
     QString endpointInfo = QString::fromLatin1(recordBytes.toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals));
 
     QList<QByteArray> txtRecord;
-    txtRecord.append("n=" + endpointInfo.toUtf8());
+    txtRecord.append(QByteArray("n=") + endpointInfo.toUtf8());
 
-    QDBusMessage reply = m_entryGroup->call("AddService",
+    QDBusMessage reply = m_entryGroup->call(u"AddService"_s,
         -1, // AVAHI_IF_UNSPEC
         -1, // AVAHI_PROTO_UNSPEC
         (uint)0,  // flags
         serviceName,
-        "_FC9F5ED42C8A._tcp",
-        "local",
-        "", // host
+        u"_FC9F5ED42C8A._tcp"_s,
+        u"local"_s,
+        u""_s, // host
         QVariant::fromValue<quint16>(port),
         QVariant::fromValue(txtRecord));
         
     if (reply.type() == QDBusMessage::ErrorMessage) {
-        qWarning() << "QuickShareDiscovery: AddService failed:" << reply.errorMessage();
+        qWarning() << u"QuickShareDiscovery: AddService failed:"_s << reply.errorMessage();
         return false;
     }
 
-    QDBusMessage commitReply = m_entryGroup->call("Commit");
+    QDBusMessage commitReply = m_entryGroup->call(u"Commit"_s);
     if (commitReply.type() == QDBusMessage::ErrorMessage) {
-        qWarning() << "QuickShareDiscovery: Commit failed:" << commitReply.errorMessage();
+        qWarning() << u"QuickShareDiscovery: Commit failed:"_s << commitReply.errorMessage();
         return false;
     }
     m_isAdvertising = true;
@@ -176,8 +178,8 @@ void QuickShareDiscovery::stopAdvertising() {
     if (!m_isAdvertising) return;
     
     if (m_entryGroup) {
-        m_entryGroup->call("Reset");
-        m_entryGroup->call("Free");
+        m_entryGroup->call(u"Reset"_s);
+        m_entryGroup->call(u"Free"_s);
         m_entryGroup->deleteLater();
         m_entryGroup = nullptr;
     }
@@ -211,21 +213,21 @@ void QuickShareDiscovery::onItemNew(int interface, int protocol, const QString& 
     Q_UNUSED(flags);
     
     QDBusInterface avahiServer(
-        "org.freedesktop.Avahi",
-        "/",
-        "org.freedesktop.Avahi.Server",
+        u"org.freedesktop.Avahi"_s,
+        u"/"_s,
+        u"org.freedesktop.Avahi.Server"_s,
         QDBusConnection::systemBus());
 
-    QDBusReply<QDBusObjectPath> reply = avahiServer.call("ServiceResolverNew",
+    QDBusReply<QDBusObjectPath> reply = avahiServer.call(u"ServiceResolverNew"_s,
         interface, protocol, name, type, domain, -1, (uint)0);
         
     if (reply.isValid()) {
         QString path = reply.value().path();
         QDBusConnection::systemBus().connect(
-            "org.freedesktop.Avahi",
+            u"org.freedesktop.Avahi"_s,
             path,
-            "org.freedesktop.Avahi.ServiceResolver",
-            "Found",
+            u"org.freedesktop.Avahi.ServiceResolver"_s,
+            u"Found"_s,
             this,
             SLOT(onServiceResolved(QDBusMessage)));
     }

--- a/plugin/src/Caelestia/Services/QuickShare/quickshare_service.cpp
+++ b/plugin/src/Caelestia/Services/QuickShare/quickshare_service.cpp
@@ -9,6 +9,8 @@
 #include <QStandardPaths>
 #include <QSysInfo>
 
+using Qt::StringLiterals::operator""_s;
+
 namespace caelestia::services {
 
 QuickShareService::QuickShareService(QObject* parent)
@@ -42,7 +44,7 @@ void QuickShareService::setEnabled(bool enabled) {
     
     if (enabled) {
         if (!m_discovery->startDiscovery()) {
-            emit errorOccurred("Avahi daemon is not running. Please start avahi-daemon to use Quick Share.");
+            emit errorOccurred(u"Avahi daemon is not running. Please start avahi-daemon to use Quick Share."_s);
             return;
         }
         m_isEnabled = true;
@@ -72,7 +74,7 @@ void QuickShareService::setVisible(bool visible) {
     
     if (visible && m_isEnabled) {
         if (!m_discovery->advertise(QSysInfo::machineHostName(), m_server->serverPort())) {
-            emit errorOccurred("Failed to advertise Quick Share. Avahi daemon might not be running.");
+            emit errorOccurred(u"Failed to advertise Quick Share. Avahi daemon might not be running."_s);
             return;
         }
         m_isVisible = true;
@@ -88,9 +90,9 @@ QVariantList QuickShareService::nearbyDevices() const {
     QVariantList list;
     for (const auto& dev : m_devices) {
         QVariantMap map;
-        map["id"] = dev.id;
-        map["name"] = dev.name;
-        map["address"] = dev.address;
+        map[u"id"_s] = dev.id;
+        map[u"name"_s] = dev.name;
+        map[u"address"_s] = dev.address;
         list.append(map);
     }
     return list;
@@ -116,11 +118,11 @@ void QuickShareService::sendFile(const QString& deviceId, const QString& filePat
         
         if (success) {
             QVariantMap entry;
-            entry["fileName"] = QFileInfo(filePath).fileName();
-            entry["filePath"] = filePath;
-            entry["timestamp"] = QDateTime::currentDateTime().toSecsSinceEpoch();
-            entry["direction"] = "sent";
-            entry["deviceName"] = deviceId;
+            entry[u"fileName"_s] = QFileInfo(filePath).fileName();
+            entry[u"filePath"_s] = filePath;
+            entry[u"timestamp"_s] = QDateTime::currentDateTime().toSecsSinceEpoch();
+            entry[u"direction"_s] = u"sent"_s;
+            entry[u"deviceName"_s] = deviceId;
             m_transferHistory.prepend(entry);
             emit transferHistoryChanged();
             saveHistory();
@@ -151,7 +153,7 @@ void QuickShareService::rejectIncomingTransfer() {
         m_pendingIncomingConnection->rejectTransfer();
         m_pendingIncomingConnection->deleteLater();
         m_pendingIncomingConnection = nullptr;
-        emit transferFinished("incoming", false);
+        emit transferFinished(u"incoming"_s, false);
     }
 }
 
@@ -187,7 +189,7 @@ void QuickShareService::onNewConnection() {
     m_pendingIncomingConnection = conn;
     
     connect(conn, &QuickShareConnection::transferRequested, this, [this, conn](const QString& fileName, qint64 fileSize) {
-        emit incomingTransferRequested(conn->deviceName().isEmpty() ? "Nearby Device" : conn->deviceName(), fileName, fileSize);
+        emit incomingTransferRequested(conn->deviceName().isEmpty() ? u"Nearby Device"_s : conn->deviceName(), fileName, fileSize);
     });
 
     connect(conn, &QuickShareConnection::pinCodeReady, this, [this](const QString& pinCode) {
@@ -198,17 +200,17 @@ void QuickShareService::onNewConnection() {
         if (success && m_pendingIncomingConnection) {
             QVariantMap entry;
             QString fileName = m_pendingIncomingConnection->incomingFileName();
-            entry["fileName"] = fileName;
-            entry["filePath"] = QDir::homePath() + "/Downloads/" + fileName;
-            entry["timestamp"] = QDateTime::currentDateTime().toSecsSinceEpoch();
-            entry["direction"] = "received";
-            entry["deviceName"] = m_pendingIncomingConnection->deviceName().isEmpty() ? "Nearby Device" : m_pendingIncomingConnection->deviceName();
+            entry[u"fileName"_s] = fileName;
+            entry[u"filePath"_s] = QDir::homePath() + u"/Downloads/"_s + fileName;
+            entry[u"timestamp"_s] = QDateTime::currentDateTime().toSecsSinceEpoch();
+            entry[u"direction"_s] = u"received"_s;
+            entry[u"deviceName"_s] = m_pendingIncomingConnection->deviceName().isEmpty() ? u"Nearby Device"_s : m_pendingIncomingConnection->deviceName();
             m_transferHistory.prepend(entry);
             emit transferHistoryChanged();
             saveHistory();
         }
         
-        emit transferFinished("incoming", success);
+        emit transferFinished(u"incoming"_s, success);
 
         if (m_pendingIncomingConnection) {
             m_pendingIncomingConnection->deleteLater();
@@ -239,7 +241,7 @@ void QuickShareService::stopBleWakeupBroadcast() {
 
 
 void QuickShareService::loadHistory() {
-    QString path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/quickshare_history.json";
+    QString path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + u"/quickshare_history.json"_s;
     QFile file(path);
     if (file.open(QIODevice::ReadOnly)) {
         QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
@@ -250,7 +252,7 @@ void QuickShareService::loadHistory() {
 }
 
 void QuickShareService::saveHistory() {
-    QString path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/quickshare_history.json";
+    QString path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + u"/quickshare_history.json"_s;
     QFile file(path);
     if (file.open(QIODevice::WriteOnly)) {
         QJsonArray arr = QJsonArray::fromVariantList(m_transferHistory);

--- a/plugin/src/Caelestia/Services/discordipc.cpp
+++ b/plugin/src/Caelestia/Services/discordipc.cpp
@@ -6,6 +6,8 @@
 #include <QCoreApplication>
 #include <QDateTime>
 
+using Qt::StringLiterals::operator""_s;
+
 namespace caelestia {
 
 enum class Opcode : int32_t {
@@ -64,7 +66,7 @@ void DiscordIpc::checkReconnect() {
     if (m_socket->state() == QLocalSocket::ConnectedState || m_socket->state() == QLocalSocket::ConnectingState) return;
 
     QString runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
-    QString pipePath = runtimeDir + "/discord-ipc-0";
+    QString pipePath = runtimeDir + u"/discord-ipc-0"_s;
 
     m_socket->connectToServer(pipePath);
 }
@@ -72,8 +74,8 @@ void DiscordIpc::checkReconnect() {
 void DiscordIpc::onSocketConnected() {
     // Send Handshake
     QJsonObject payload;
-    payload["v"] = 1;
-    payload["client_id"] = m_clientId;
+    payload[u"v"_s] = 1;
+    payload[u"client_id"_s] = m_clientId;
     sendFrame(static_cast<int>(Opcode::Handshake), payload);
 }
 
@@ -117,8 +119,8 @@ void DiscordIpc::onReadyRead() {
 
 void DiscordIpc::processPayload(int opcode, const QJsonObject& payload) {
     if (opcode == static_cast<int>(Opcode::Frame)) {
-        if (payload.contains("cmd") && payload["cmd"].toString() == "DISPATCH") {
-            if (payload.contains("evt") && payload["evt"].toString() == "READY") {
+        if (payload.contains(u"cmd"_s) && payload[u"cmd"_s].toString() == u"DISPATCH"_s) {
+            if (payload.contains(u"evt"_s) && payload[u"evt"_s].toString() == u"READY"_s) {
                 m_connected = true;
                 emit connectedChanged();
             }
@@ -148,13 +150,13 @@ void DiscordIpc::sendActivity(const QJsonObject& activity) {
     if (!m_connected) return;
 
     QJsonObject args;
-    args["pid"] = static_cast<int>(QCoreApplication::applicationPid());
-    args["activity"] = activity;
+    args[u"pid"_s] = static_cast<int>(QCoreApplication::applicationPid());
+    args[u"activity"_s] = activity;
 
     QJsonObject payload;
-    payload["cmd"] = "SET_ACTIVITY";
-    payload["args"] = args;
-    payload["nonce"] = QString::number(QDateTime::currentMSecsSinceEpoch());
+    payload[u"cmd"_s] = u"SET_ACTIVITY"_s;
+    payload[u"args"_s] = args;
+    payload[u"nonce"_s] = QString::number(QDateTime::currentMSecsSinceEpoch());
 
     sendFrame(static_cast<int>(Opcode::Frame), payload);
 }
@@ -163,12 +165,12 @@ void DiscordIpc::clearActivity() {
     if (!m_connected) return;
 
     QJsonObject args;
-    args["pid"] = static_cast<int>(QCoreApplication::applicationPid());
+    args[u"pid"_s] = static_cast<int>(QCoreApplication::applicationPid());
 
     QJsonObject payload;
-    payload["cmd"] = "SET_ACTIVITY";
-    payload["args"] = args;
-    payload["nonce"] = QString::number(QDateTime::currentMSecsSinceEpoch());
+    payload[u"cmd"_s] = u"SET_ACTIVITY"_s;
+    payload[u"args"_s] = args;
+    payload[u"nonce"_s] = QString::number(QDateTime::currentMSecsSinceEpoch());
 
     sendFrame(static_cast<int>(Opcode::Frame), payload);
 }

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -121,7 +121,7 @@ QString CUtils::sha256(const QString& path) {
     hash.addData(&file);
     file.close();
 
-    return hash.result().toHex();
+    return QString::fromLatin1(hash.result().toHex());
 }
 
 bool CUtils::fileExists(const QString& path) {


### PR DESCRIPTION
upstream disabled implicit ASCII/bytearray casts
port fork-only sources to u""_s literals where QString is expected, keep plain literals for QByteArray/protobuf setters, and fix a name shadowing in SessionConfig::buttons()