### PR TITLE
shimeji: drop stale Caelestia.Internal import

### DIFF
--- a/modules/shimeji/Shimeji.qml
+++ b/modules/shimeji/Shimeji.qml
@@ -3,7 +3,6 @@ import Quickshell
 import Quickshell.Wayland
 import Quickshell.Io
 import Caelestia.Config
-import Caelestia.Internal
 import qs.components.containers
 import qs.components
 import qs.services


### PR DESCRIPTION
Shimeji.qml still imported Caelestia.Internal, which was removed in the plugin rearrange (#1896). The import was unused anyway — with it gone the shell loads past the shimeji module again. One line deleted.