### PR TITLE
Sync upstream caelestia-dots/shell (7f39105e)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - "**"
+      - "!**/*.md"
+      - "!.github/**"
+      - ".github/workflows/build.yml"
+      - "!.vscode/**"
+      - "!assets/**"
+      - "!.gitignore"
 
 jobs:
   build-nix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - "**"
+      - "!**/*.md"
+      - "!.github/**"
+      - ".github/workflows/build.yml"
+      - "!.vscode/**"
+      - "!assets/**"
+      - "!.gitignore"
+      - "!**/*.nix"
+      - "!**/flake.lock"
 
 jobs:
   lint-qml:

--- a/components/controls/StyledRadioButton.qml
+++ b/components/controls/StyledRadioButton.qml
@@ -49,6 +49,8 @@ RadioButton {
         font: root.font
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: outerCircle.right
+        anchors.right: parent.right
         anchors.leftMargin: Tokens.spacing.medium
+        elide: Text.ElideRight
     }
 }

--- a/modules/bar/popouts/AudioPopout.qml
+++ b/modules/bar/popouts/AudioPopout.qml
@@ -15,7 +15,7 @@ Item {
 
     required property PopoutState popouts
 
-    implicitWidth: layout.implicitWidth + Tokens.padding.medium * 2
+    implicitWidth: Tokens.sizes.bar.audioWidth
     implicitHeight: layout.implicitHeight + Tokens.padding.medium * 2
 
     ButtonGroup {
@@ -30,6 +30,7 @@ Item {
         id: layout
 
         anchors.left: parent.left
+        anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
         spacing: Tokens.spacing.medium
 
@@ -46,6 +47,7 @@ Item {
 
                 required property PwNode modelData
 
+                Layout.fillWidth: true
                 ButtonGroup.group: sinks
                 checked: Audio.sink?.id === modelData.id
                 onClicked: Audio.setAudioSink(modelData)
@@ -65,6 +67,7 @@ Item {
             StyledRadioButton {
                 required property PwNode modelData
 
+                Layout.fillWidth: true
                 ButtonGroup.group: sources
                 checked: Audio.source?.id === modelData.id
                 onClicked: Audio.setAudioSource(modelData)

--- a/modules/launcher/services/M3Variants.qml
+++ b/modules/launcher/services/M3Variants.qml
@@ -5,6 +5,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Caelestia.Config
+import Caelestia.I18n
 import qs.services
 import qs.utils
 

--- a/modules/nexus/common/PageBase.qml
+++ b/modules/nexus/common/PageBase.qml
@@ -14,7 +14,7 @@ ColumnLayout {
 
     required property string title
     required property NexusState nState
-    readonly property GlobalConfig targetConfig: GlobalConfig.forScreen(nState.targetScreen)
+    readonly property var targetConfig: GlobalConfig.forScreen(nState.targetScreen)
     property bool isSubPage
     property bool scrollable: true
     readonly property int cappedWidth: Math.min(Tokens.sizes.nexus.maxContentWidth, width)

--- a/modules/nexus/pages/AudioPage.qml
+++ b/modules/nexus/pages/AudioPage.qml
@@ -3,6 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import Caelestia.Config
+import Caelestia.I18n
 import qs.components
 import qs.components.controls
 import qs.services

--- a/modules/nexus/pages/LanguageAndRegion.qml
+++ b/modules/nexus/pages/LanguageAndRegion.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import Quickshell
 import Caelestia.Config
 import Caelestia.I18n
 import qs.components
@@ -44,47 +45,36 @@ PageBase {
             text: Tr.tr("Language")
         }
 
-        // Read-only: the shell follows the system locale (no in-shell translations yet)
-        ConnectedRect {
-            Layout.fillWidth: true
+        SelectRow {
             first: true
             last: true
-            implicitHeight: localeLayout.implicitHeight + localeLayout.anchors.margins * 2
+            label: Tr.tr("UI language")
+            subtext: Tr.tr("The language used in the shell UI")
+            active: menuItems.find(i => i.modelData === Tr.language) ?? autoLang
+            onSelected: item => {
+                Tr.language = item.modelData ?? ""; // qmllint disable missing-property
+            }
 
-            RowLayout {
-                id: localeLayout
+            menuItems: [autoLang, ...langItems.instances]
 
-                anchors.fill: parent
-                anchors.margins: Tokens.padding.medium
-                anchors.leftMargin: Tokens.padding.largeIncreased
-                anchors.rightMargin: Tokens.padding.largeIncreased
-                spacing: Tokens.spacing.medium
+            MenuItem {
+                id: autoLang
 
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: 0
+                text: Tr.tr("Auto")
+            }
 
-                    StyledText {
-                        Layout.fillWidth: true
-                        text: Tr.tr("System language")
-                        font: Tokens.font.body.small
-                        elide: Text.ElideRight
+            Variants {
+                id: langItems
+
+                model: Tr.supportedLanguages
+
+                MenuItem {
+                    required property string modelData
+
+                    text: {
+                        const locale = Qt.locale(modelData);
+                        return locale.name === "C" ? modelData : locale.nativeLanguageName || locale.name;
                     }
-
-                    StyledText {
-                        Layout.fillWidth: true
-                        // TRANSLATORS: %1 = a locale code such as en_AU
-                        text: Tr.tr("Follows your system locale (%1)").arg(Qt.locale().name)
-                        color: Colours.palette.m3outline
-                        font: Tokens.font.label.small
-                        elide: Text.ElideRight
-                    }
-                }
-
-                StyledText {
-                    text: Qt.locale().nativeLanguageName || Qt.locale().name
-                    color: Colours.palette.m3onSurfaceVariant
-                    font: Tokens.font.body.small
                 }
             }
         }

--- a/modules/nexus/pages/panels/DashboardPanel.qml
+++ b/modules/nexus/pages/panels/DashboardPanel.qml
@@ -3,6 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import Caelestia.Config
+import Caelestia.I18n
 import M3Shapes
 import qs.components
 import qs.components.controls

--- a/modules/nexus/pages/panels/SidebarPanel.qml
+++ b/modules/nexus/pages/panels/SidebarPanel.qml
@@ -4,6 +4,7 @@ import QtQuick
 import QtQuick.Layouts
 import Quickshell
 import Caelestia.Config
+import Caelestia.I18n
 import qs.components
 import qs.components.controls
 import qs.modules.nexus.common

--- a/modules/nexus/pages/panels/TaskbarPanel.qml
+++ b/modules/nexus/pages/panels/TaskbarPanel.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick.Layouts
 import Caelestia.Config
+import Caelestia.I18n
 import qs.components.controls
 import qs.modules.nexus.common
 

--- a/modules/nexus/pages/panels/taskbar/BarStatusIcons.qml
+++ b/modules/nexus/pages/panels/taskbar/BarStatusIcons.qml
@@ -3,6 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import Caelestia.Config
+import Caelestia.I18n
 import qs.components
 import qs.services
 import qs.modules.nexus.common

--- a/modules/nexus/pages/tokens/BarDashboardPage.qml
+++ b/modules/nexus/pages/tokens/BarDashboardPage.qml
@@ -30,7 +30,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.sizes.bar.innerWidth = v
-            onReset: { TokenConfig.sizes.bar.innerWidth = TokenConfig.defaults().sizes.bar.innerWidth; TokenConfig.sizes.bar.resetOption("innerWidth"); }
+            onReset: { TokenConfig.sizes.bar.resetOption("innerWidth"); }
         }
 
         StepperRow {
@@ -43,7 +43,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.bar.windowPreviewSize = v
-            onReset: { TokenConfig.sizes.bar.windowPreviewSize = TokenConfig.defaults().sizes.bar.windowPreviewSize; TokenConfig.sizes.bar.resetOption("windowPreviewSize"); }
+            onReset: { TokenConfig.sizes.bar.resetOption("windowPreviewSize"); }
         }
 
         StepperRow {
@@ -56,7 +56,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.bar.trayMenuWidth = v
-            onReset: { TokenConfig.sizes.bar.trayMenuWidth = TokenConfig.defaults().sizes.bar.trayMenuWidth; TokenConfig.sizes.bar.resetOption("trayMenuWidth"); }
+            onReset: { TokenConfig.sizes.bar.resetOption("trayMenuWidth"); }
         }
 
         StepperRow {
@@ -69,7 +69,7 @@ PageBase {
             stepSize: 5
             showReset: true
             onMoved: v => TokenConfig.sizes.bar.batteryWidth = v
-            onReset: { TokenConfig.sizes.bar.batteryWidth = TokenConfig.defaults().sizes.bar.batteryWidth; TokenConfig.sizes.bar.resetOption("batteryWidth"); }
+            onReset: { TokenConfig.sizes.bar.resetOption("batteryWidth"); }
         }
 
         StepperRow {
@@ -82,7 +82,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.bar.networkWidth = v
-            onReset: { TokenConfig.sizes.bar.networkWidth = TokenConfig.defaults().sizes.bar.networkWidth; TokenConfig.sizes.bar.resetOption("networkWidth"); }
+            onReset: { TokenConfig.sizes.bar.resetOption("networkWidth"); }
         }
 
         StepperRow {
@@ -96,7 +96,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.bar.kbLayoutWidth = v
-            onReset: { TokenConfig.sizes.bar.kbLayoutWidth = TokenConfig.defaults().sizes.bar.kbLayoutWidth; TokenConfig.sizes.bar.resetOption("kbLayoutWidth"); }
+            onReset: { TokenConfig.sizes.bar.resetOption("kbLayoutWidth"); }
         }
 
         SectionHeader {
@@ -113,7 +113,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.userWidth = v
-            onReset: { TokenConfig.sizes.dashboard.userWidth = TokenConfig.defaults().sizes.dashboard.userWidth; TokenConfig.sizes.dashboard.resetOption("userWidth"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("userWidth"); }
         }
 
         StepperRow {
@@ -126,7 +126,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.logoSize = v
-            onReset: { TokenConfig.sizes.dashboard.logoSize = TokenConfig.defaults().sizes.dashboard.logoSize; TokenConfig.sizes.dashboard.resetOption("logoSize"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("logoSize"); }
         }
 
         StepperRow {
@@ -139,7 +139,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.uptimeSize = v
-            onReset: { TokenConfig.sizes.dashboard.uptimeSize = TokenConfig.defaults().sizes.dashboard.uptimeSize; TokenConfig.sizes.dashboard.resetOption("uptimeSize"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("uptimeSize"); }
         }
 
         StepperRow {
@@ -152,7 +152,7 @@ PageBase {
             stepSize: 5
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.dateTimeWidth = v
-            onReset: { TokenConfig.sizes.dashboard.dateTimeWidth = TokenConfig.defaults().sizes.dashboard.dateTimeWidth; TokenConfig.sizes.dashboard.resetOption("dateTimeWidth"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("dateTimeWidth"); }
         }
 
         StepperRow {
@@ -165,7 +165,7 @@ PageBase {
             stepSize: 5
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.weatherWidth = v
-            onReset: { TokenConfig.sizes.dashboard.weatherWidth = TokenConfig.defaults().sizes.dashboard.weatherWidth; TokenConfig.sizes.dashboard.resetOption("weatherWidth"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("weatherWidth"); }
         }
 
         StepperRow {
@@ -178,7 +178,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.mediaWidth = v
-            onReset: { TokenConfig.sizes.dashboard.mediaWidth = TokenConfig.defaults().sizes.dashboard.mediaWidth; TokenConfig.sizes.dashboard.resetOption("mediaWidth"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("mediaWidth"); }
         }
 
         StepperRow {
@@ -191,7 +191,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.mediaSectionWidth = v
-            onReset: { TokenConfig.sizes.dashboard.mediaSectionWidth = TokenConfig.defaults().sizes.dashboard.mediaSectionWidth; TokenConfig.sizes.dashboard.resetOption("mediaSectionWidth"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("mediaSectionWidth"); }
         }
 
         StepperRow {
@@ -204,7 +204,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.mediaCoverArtSize = v
-            onReset: { TokenConfig.sizes.dashboard.mediaCoverArtSize = TokenConfig.defaults().sizes.dashboard.mediaCoverArtSize; TokenConfig.sizes.dashboard.resetOption("mediaCoverArtSize"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("mediaCoverArtSize"); }
         }
 
         StepperRow {
@@ -217,7 +217,7 @@ PageBase {
             stepSize: 20
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.mediaTabWidth = v
-            onReset: { TokenConfig.sizes.dashboard.mediaTabWidth = TokenConfig.defaults().sizes.dashboard.mediaTabWidth; TokenConfig.sizes.dashboard.resetOption("mediaTabWidth"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("mediaTabWidth"); }
         }
 
         StepperRow {
@@ -231,7 +231,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.dashboard.mediaTabHeight = v
-            onReset: { TokenConfig.sizes.dashboard.mediaTabHeight = TokenConfig.defaults().sizes.dashboard.mediaTabHeight; TokenConfig.sizes.dashboard.resetOption("mediaTabHeight"); }
+            onReset: { TokenConfig.sizes.dashboard.resetOption("mediaTabHeight"); }
         }
     }
 }

--- a/modules/nexus/pages/tokens/FontSizesPage.qml
+++ b/modules/nexus/pages/tokens/FontSizesPage.qml
@@ -30,7 +30,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.fontSize.small = v
-            onReset: { TokenConfig.appearance.fontSize.small = TokenConfig.defaults().appearance.fontSize.small; TokenConfig.appearance.fontSize.resetOption("small"); }
+            onReset: { TokenConfig.appearance.fontSize.resetOption("small"); }
         }
 
         StepperRow {
@@ -43,7 +43,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.fontSize.smaller = v
-            onReset: { TokenConfig.appearance.fontSize.smaller = TokenConfig.defaults().appearance.fontSize.smaller; TokenConfig.appearance.fontSize.resetOption("smaller"); }
+            onReset: { TokenConfig.appearance.fontSize.resetOption("smaller"); }
         }
 
         StepperRow {
@@ -56,7 +56,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.fontSize.normal = v
-            onReset: { TokenConfig.appearance.fontSize.normal = TokenConfig.defaults().appearance.fontSize.normal; TokenConfig.appearance.fontSize.resetOption("normal"); }
+            onReset: { TokenConfig.appearance.fontSize.resetOption("normal"); }
         }
 
         StepperRow {
@@ -69,7 +69,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.fontSize.larger = v
-            onReset: { TokenConfig.appearance.fontSize.larger = TokenConfig.defaults().appearance.fontSize.larger; TokenConfig.appearance.fontSize.resetOption("larger"); }
+            onReset: { TokenConfig.appearance.fontSize.resetOption("larger"); }
         }
 
         StepperRow {
@@ -82,7 +82,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.fontSize.large = v
-            onReset: { TokenConfig.appearance.fontSize.large = TokenConfig.defaults().appearance.fontSize.large; TokenConfig.appearance.fontSize.resetOption("large"); }
+            onReset: { TokenConfig.appearance.fontSize.resetOption("large"); }
         }
 
         StepperRow {
@@ -96,7 +96,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.fontSize.extraLarge = v
-            onReset: { TokenConfig.appearance.fontSize.extraLarge = TokenConfig.defaults().appearance.fontSize.extraLarge; TokenConfig.appearance.fontSize.resetOption("extraLarge"); }
+            onReset: { TokenConfig.appearance.fontSize.resetOption("extraLarge"); }
         }
 
         SectionHeader {
@@ -113,7 +113,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.fontSize.monoSmall = v
-            onReset: { TokenConfig.appearance.fontSize.monoSmall = TokenConfig.defaults().appearance.fontSize.monoSmall; TokenConfig.appearance.fontSize.resetOption("monoSmall"); }
+            onReset: { TokenConfig.appearance.fontSize.resetOption("monoSmall"); }
         }
 
         StepperRow {
@@ -126,7 +126,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.fontSize.monoMedium = v
-            onReset: { TokenConfig.appearance.fontSize.monoMedium = TokenConfig.defaults().appearance.fontSize.monoMedium; TokenConfig.appearance.fontSize.resetOption("monoMedium"); }
+            onReset: { TokenConfig.appearance.fontSize.resetOption("monoMedium"); }
         }
 
         StepperRow {
@@ -140,7 +140,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.fontSize.monoLarge = v
-            onReset: { TokenConfig.appearance.fontSize.monoLarge = TokenConfig.defaults().appearance.fontSize.monoLarge; TokenConfig.appearance.fontSize.resetOption("monoLarge"); }
+            onReset: { TokenConfig.appearance.fontSize.resetOption("monoLarge"); }
         }
     }
 }

--- a/modules/nexus/pages/tokens/RoundingSpacingPage.qml
+++ b/modules/nexus/pages/tokens/RoundingSpacingPage.qml
@@ -30,7 +30,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.rounding.extraSmall = v
-            onReset: { TokenConfig.appearance.rounding.extraSmall = TokenConfig.defaults().appearance.rounding.extraSmall; TokenConfig.appearance.rounding.resetOption("extraSmall"); }
+            onReset: { TokenConfig.appearance.rounding.resetOption("extraSmall"); }
         }
 
         StepperRow {
@@ -43,7 +43,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.rounding.small = v
-            onReset: { TokenConfig.appearance.rounding.small = TokenConfig.defaults().appearance.rounding.small; TokenConfig.appearance.rounding.resetOption("small"); }
+            onReset: { TokenConfig.appearance.rounding.resetOption("small"); }
         }
 
         StepperRow {
@@ -56,7 +56,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.rounding.medium = v
-            onReset: { TokenConfig.appearance.rounding.medium = TokenConfig.defaults().appearance.rounding.medium; TokenConfig.appearance.rounding.resetOption("medium"); }
+            onReset: { TokenConfig.appearance.rounding.resetOption("medium"); }
         }
 
         StepperRow {
@@ -69,7 +69,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.rounding.large = v
-            onReset: { TokenConfig.appearance.rounding.large = TokenConfig.defaults().appearance.rounding.large; TokenConfig.appearance.rounding.resetOption("large"); }
+            onReset: { TokenConfig.appearance.rounding.resetOption("large"); }
         }
 
         StepperRow {
@@ -82,7 +82,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.rounding.largeIncreased = v
-            onReset: { TokenConfig.appearance.rounding.largeIncreased = TokenConfig.defaults().appearance.rounding.largeIncreased; TokenConfig.appearance.rounding.resetOption("largeIncreased"); }
+            onReset: { TokenConfig.appearance.rounding.resetOption("largeIncreased"); }
         }
 
         StepperRow {
@@ -95,7 +95,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.rounding.extraLarge = v
-            onReset: { TokenConfig.appearance.rounding.extraLarge = TokenConfig.defaults().appearance.rounding.extraLarge; TokenConfig.appearance.rounding.resetOption("extraLarge"); }
+            onReset: { TokenConfig.appearance.rounding.resetOption("extraLarge"); }
         }
 
         StepperRow {
@@ -108,7 +108,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.rounding.extraLargeIncreased = v
-            onReset: { TokenConfig.appearance.rounding.extraLargeIncreased = TokenConfig.defaults().appearance.rounding.extraLargeIncreased; TokenConfig.appearance.rounding.resetOption("extraLargeIncreased"); }
+            onReset: { TokenConfig.appearance.rounding.resetOption("extraLargeIncreased"); }
         }
 
         StepperRow {
@@ -122,7 +122,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.appearance.rounding.extraExtraLarge = v
-            onReset: { TokenConfig.appearance.rounding.extraExtraLarge = TokenConfig.defaults().appearance.rounding.extraExtraLarge; TokenConfig.appearance.rounding.resetOption("extraExtraLarge"); }
+            onReset: { TokenConfig.appearance.rounding.resetOption("extraExtraLarge"); }
         }
 
         SectionHeader {
@@ -139,7 +139,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.spacing.extraSmall = v
-            onReset: { TokenConfig.appearance.spacing.extraSmall = TokenConfig.defaults().appearance.spacing.extraSmall; TokenConfig.appearance.spacing.resetOption("extraSmall"); }
+            onReset: { TokenConfig.appearance.spacing.resetOption("extraSmall"); }
         }
 
         StepperRow {
@@ -152,7 +152,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.spacing.small = v
-            onReset: { TokenConfig.appearance.spacing.small = TokenConfig.defaults().appearance.spacing.small; TokenConfig.appearance.spacing.resetOption("small"); }
+            onReset: { TokenConfig.appearance.spacing.resetOption("small"); }
         }
 
         StepperRow {
@@ -165,7 +165,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.spacing.medium = v
-            onReset: { TokenConfig.appearance.spacing.medium = TokenConfig.defaults().appearance.spacing.medium; TokenConfig.appearance.spacing.resetOption("medium"); }
+            onReset: { TokenConfig.appearance.spacing.resetOption("medium"); }
         }
 
         StepperRow {
@@ -178,7 +178,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.spacing.large = v
-            onReset: { TokenConfig.appearance.spacing.large = TokenConfig.defaults().appearance.spacing.large; TokenConfig.appearance.spacing.resetOption("large"); }
+            onReset: { TokenConfig.appearance.spacing.resetOption("large"); }
         }
 
         StepperRow {
@@ -191,7 +191,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.spacing.largeIncreased = v
-            onReset: { TokenConfig.appearance.spacing.largeIncreased = TokenConfig.defaults().appearance.spacing.largeIncreased; TokenConfig.appearance.spacing.resetOption("largeIncreased"); }
+            onReset: { TokenConfig.appearance.spacing.resetOption("largeIncreased"); }
         }
 
         StepperRow {
@@ -204,7 +204,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.spacing.extraLarge = v
-            onReset: { TokenConfig.appearance.spacing.extraLarge = TokenConfig.defaults().appearance.spacing.extraLarge; TokenConfig.appearance.spacing.resetOption("extraLarge"); }
+            onReset: { TokenConfig.appearance.spacing.resetOption("extraLarge"); }
         }
 
         StepperRow {
@@ -217,7 +217,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.spacing.extraLargeIncreased = v
-            onReset: { TokenConfig.appearance.spacing.extraLargeIncreased = TokenConfig.defaults().appearance.spacing.extraLargeIncreased; TokenConfig.appearance.spacing.resetOption("extraLargeIncreased"); }
+            onReset: { TokenConfig.appearance.spacing.resetOption("extraLargeIncreased"); }
         }
 
         StepperRow {
@@ -231,7 +231,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.appearance.spacing.extraExtraLarge = v
-            onReset: { TokenConfig.appearance.spacing.extraExtraLarge = TokenConfig.defaults().appearance.spacing.extraExtraLarge; TokenConfig.appearance.spacing.resetOption("extraExtraLarge"); }
+            onReset: { TokenConfig.appearance.spacing.resetOption("extraExtraLarge"); }
         }
 
         SectionHeader {
@@ -248,7 +248,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.padding.extraSmall = v
-            onReset: { TokenConfig.appearance.padding.extraSmall = TokenConfig.defaults().appearance.padding.extraSmall; TokenConfig.appearance.padding.resetOption("extraSmall"); }
+            onReset: { TokenConfig.appearance.padding.resetOption("extraSmall"); }
         }
 
         StepperRow {
@@ -261,7 +261,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.padding.small = v
-            onReset: { TokenConfig.appearance.padding.small = TokenConfig.defaults().appearance.padding.small; TokenConfig.appearance.padding.resetOption("small"); }
+            onReset: { TokenConfig.appearance.padding.resetOption("small"); }
         }
 
         StepperRow {
@@ -274,7 +274,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.padding.medium = v
-            onReset: { TokenConfig.appearance.padding.medium = TokenConfig.defaults().appearance.padding.medium; TokenConfig.appearance.padding.resetOption("medium"); }
+            onReset: { TokenConfig.appearance.padding.resetOption("medium"); }
         }
 
         StepperRow {
@@ -287,7 +287,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.padding.large = v
-            onReset: { TokenConfig.appearance.padding.large = TokenConfig.defaults().appearance.padding.large; TokenConfig.appearance.padding.resetOption("large"); }
+            onReset: { TokenConfig.appearance.padding.resetOption("large"); }
         }
 
         StepperRow {
@@ -300,7 +300,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.padding.largeIncreased = v
-            onReset: { TokenConfig.appearance.padding.largeIncreased = TokenConfig.defaults().appearance.padding.largeIncreased; TokenConfig.appearance.padding.resetOption("largeIncreased"); }
+            onReset: { TokenConfig.appearance.padding.resetOption("largeIncreased"); }
         }
 
         StepperRow {
@@ -313,7 +313,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.padding.extraLarge = v
-            onReset: { TokenConfig.appearance.padding.extraLarge = TokenConfig.defaults().appearance.padding.extraLarge; TokenConfig.appearance.padding.resetOption("extraLarge"); }
+            onReset: { TokenConfig.appearance.padding.resetOption("extraLarge"); }
         }
 
         StepperRow {
@@ -326,7 +326,7 @@ PageBase {
             stepSize: 1
             showReset: true
             onMoved: v => TokenConfig.appearance.padding.extraLargeIncreased = v
-            onReset: { TokenConfig.appearance.padding.extraLargeIncreased = TokenConfig.defaults().appearance.padding.extraLargeIncreased; TokenConfig.appearance.padding.resetOption("extraLargeIncreased"); }
+            onReset: { TokenConfig.appearance.padding.resetOption("extraLargeIncreased"); }
         }
 
         StepperRow {
@@ -340,7 +340,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.appearance.padding.extraExtraLarge = v
-            onReset: { TokenConfig.appearance.padding.extraExtraLarge = TokenConfig.defaults().appearance.padding.extraExtraLarge; TokenConfig.appearance.padding.resetOption("extraExtraLarge"); }
+            onReset: { TokenConfig.appearance.padding.resetOption("extraExtraLarge"); }
         }
     }
 }

--- a/modules/nexus/pages/tokens/ShellElementsPage.qml
+++ b/modules/nexus/pages/tokens/ShellElementsPage.qml
@@ -30,7 +30,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.launcher.itemWidth = v
-            onReset: { TokenConfig.sizes.launcher.itemWidth = TokenConfig.defaults().sizes.launcher.itemWidth; TokenConfig.sizes.launcher.resetOption("itemWidth"); }
+            onReset: { TokenConfig.sizes.launcher.resetOption("itemWidth"); }
         }
 
         StepperRow {
@@ -43,7 +43,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.sizes.launcher.itemHeight = v
-            onReset: { TokenConfig.sizes.launcher.itemHeight = TokenConfig.defaults().sizes.launcher.itemHeight; TokenConfig.sizes.launcher.resetOption("itemHeight"); }
+            onReset: { TokenConfig.sizes.launcher.resetOption("itemHeight"); }
         }
 
         StepperRow {
@@ -56,7 +56,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.launcher.wallpaperWidth = v
-            onReset: { TokenConfig.sizes.launcher.wallpaperWidth = TokenConfig.defaults().sizes.launcher.wallpaperWidth; TokenConfig.sizes.launcher.resetOption("wallpaperWidth"); }
+            onReset: { TokenConfig.sizes.launcher.resetOption("wallpaperWidth"); }
         }
 
         StepperRow {
@@ -70,7 +70,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.launcher.wallpaperHeight = v
-            onReset: { TokenConfig.sizes.launcher.wallpaperHeight = TokenConfig.defaults().sizes.launcher.wallpaperHeight; TokenConfig.sizes.launcher.resetOption("wallpaperHeight"); }
+            onReset: { TokenConfig.sizes.launcher.resetOption("wallpaperHeight"); }
         }
 
         SectionHeader {
@@ -87,7 +87,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.notifs.width = v
-            onReset: { TokenConfig.sizes.notifs.width = TokenConfig.defaults().sizes.notifs.width; TokenConfig.sizes.notifs.resetOption("width"); }
+            onReset: { TokenConfig.sizes.notifs.resetOption("width"); }
         }
 
         StepperRow {
@@ -100,7 +100,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.sizes.notifs.image = v
-            onReset: { TokenConfig.sizes.notifs.image = TokenConfig.defaults().sizes.notifs.image; TokenConfig.sizes.notifs.resetOption("image"); }
+            onReset: { TokenConfig.sizes.notifs.resetOption("image"); }
         }
 
         StepperRow {
@@ -114,7 +114,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.sizes.notifs.badge = v
-            onReset: { TokenConfig.sizes.notifs.badge = TokenConfig.defaults().sizes.notifs.badge; TokenConfig.sizes.notifs.resetOption("badge"); }
+            onReset: { TokenConfig.sizes.notifs.resetOption("badge"); }
         }
 
         SectionHeader {
@@ -131,7 +131,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.sizes.osd.sliderWidth = v
-            onReset: { TokenConfig.sizes.osd.sliderWidth = TokenConfig.defaults().sizes.osd.sliderWidth; TokenConfig.sizes.osd.resetOption("sliderWidth"); }
+            onReset: { TokenConfig.sizes.osd.resetOption("sliderWidth"); }
         }
 
         StepperRow {
@@ -145,7 +145,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.osd.sliderHeight = v
-            onReset: { TokenConfig.sizes.osd.sliderHeight = TokenConfig.defaults().sizes.osd.sliderHeight; TokenConfig.sizes.osd.resetOption("sliderHeight"); }
+            onReset: { TokenConfig.sizes.osd.resetOption("sliderHeight"); }
         }
 
         SectionHeader {
@@ -162,7 +162,7 @@ PageBase {
             stepSize: 5
             showReset: true
             onMoved: v => TokenConfig.sizes.session.button = v
-            onReset: { TokenConfig.sizes.session.button = TokenConfig.defaults().sizes.session.button; TokenConfig.sizes.session.resetOption("button"); }
+            onReset: { TokenConfig.sizes.session.resetOption("button"); }
         }
 
         StepperRow {
@@ -175,7 +175,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.sidebar.width = v
-            onReset: { TokenConfig.sizes.sidebar.width = TokenConfig.defaults().sizes.sidebar.width; TokenConfig.sizes.sidebar.resetOption("width"); }
+            onReset: { TokenConfig.sizes.sidebar.resetOption("width"); }
         }
 
         StepperRow {
@@ -188,7 +188,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.utilities.width = v
-            onReset: { TokenConfig.sizes.utilities.width = TokenConfig.defaults().sizes.utilities.width; TokenConfig.sizes.utilities.resetOption("width"); }
+            onReset: { TokenConfig.sizes.utilities.resetOption("width"); }
         }
 
         StepperRow {
@@ -202,7 +202,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.utilities.toastWidth = v
-            onReset: { TokenConfig.sizes.utilities.toastWidth = TokenConfig.defaults().sizes.utilities.toastWidth; TokenConfig.sizes.utilities.resetOption("toastWidth"); }
+            onReset: { TokenConfig.sizes.utilities.resetOption("toastWidth"); }
         }
     }
 }

--- a/modules/nexus/pages/tokens/WindowLockPage.qml
+++ b/modules/nexus/pages/tokens/WindowLockPage.qml
@@ -28,7 +28,7 @@ PageBase {
             valueLabel: value.toFixed(2)
             showReset: true
             onMoved: v => TokenConfig.sizes.lock.heightMult = v
-            onReset: { TokenConfig.sizes.lock.heightMult = TokenConfig.defaults().sizes.lock.heightMult; TokenConfig.sizes.lock.resetOption("heightMult"); }
+            onReset: { TokenConfig.sizes.lock.resetOption("heightMult"); }
         }
 
         SliderRow {
@@ -39,7 +39,7 @@ PageBase {
             valueLabel: (1.0 + value * 1.5).toFixed(2)
             showReset: true
             onMoved: v => TokenConfig.sizes.lock.ratio = 1.0 + v * 1.5
-            onReset: { TokenConfig.sizes.lock.ratio = TokenConfig.defaults().sizes.lock.ratio; TokenConfig.sizes.lock.resetOption("ratio"); }
+            onReset: { TokenConfig.sizes.lock.resetOption("ratio"); }
         }
 
         StepperRow {
@@ -52,7 +52,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.lock.centerWidth = v
-            onReset: { TokenConfig.sizes.lock.centerWidth = TokenConfig.defaults().sizes.lock.centerWidth; TokenConfig.sizes.lock.resetOption("centerWidth"); }
+            onReset: { TokenConfig.sizes.lock.resetOption("centerWidth"); }
         }
 
         StepperRow {
@@ -65,7 +65,7 @@ PageBase {
             stepSize: 2
             showReset: true
             onMoved: v => TokenConfig.sizes.lock.forecastItemWidth = v
-            onReset: { TokenConfig.sizes.lock.forecastItemWidth = TokenConfig.defaults().sizes.lock.forecastItemWidth; TokenConfig.sizes.lock.resetOption("forecastItemWidth"); }
+            onReset: { TokenConfig.sizes.lock.resetOption("forecastItemWidth"); }
         }
 
         StepperRow {
@@ -78,7 +78,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.lock.largeLogoWidth = v
-            onReset: { TokenConfig.sizes.lock.largeLogoWidth = TokenConfig.defaults().sizes.lock.largeLogoWidth; TokenConfig.sizes.lock.resetOption("largeLogoWidth"); }
+            onReset: { TokenConfig.sizes.lock.resetOption("largeLogoWidth"); }
         }
 
         StepperRow {
@@ -92,7 +92,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.lock.largeFontWidth = v
-            onReset: { TokenConfig.sizes.lock.largeFontWidth = TokenConfig.defaults().sizes.lock.largeFontWidth; TokenConfig.sizes.lock.resetOption("largeFontWidth"); }
+            onReset: { TokenConfig.sizes.lock.resetOption("largeFontWidth"); }
         }
 
         SectionHeader {
@@ -107,7 +107,7 @@ PageBase {
             valueLabel: value.toFixed(2)
             showReset: true
             onMoved: v => TokenConfig.sizes.nexus.heightMult = v
-            onReset: { TokenConfig.sizes.nexus.heightMult = TokenConfig.defaults().sizes.nexus.heightMult; TokenConfig.sizes.nexus.resetOption("heightMult"); }
+            onReset: { TokenConfig.sizes.nexus.resetOption("heightMult"); }
         }
 
         SliderRow {
@@ -118,7 +118,7 @@ PageBase {
             valueLabel: (1.0 + value * 1.5).toFixed(2)
             showReset: true
             onMoved: v => TokenConfig.sizes.nexus.ratio = 1.0 + v * 1.5
-            onReset: { TokenConfig.sizes.nexus.ratio = TokenConfig.defaults().sizes.nexus.ratio; TokenConfig.sizes.nexus.resetOption("ratio"); }
+            onReset: { TokenConfig.sizes.nexus.resetOption("ratio"); }
         }
 
         StepperRow {
@@ -131,7 +131,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.nexus.minWidth = v
-            onReset: { TokenConfig.sizes.nexus.minWidth = TokenConfig.defaults().sizes.nexus.minWidth; TokenConfig.sizes.nexus.resetOption("minWidth"); }
+            onReset: { TokenConfig.sizes.nexus.resetOption("minWidth"); }
         }
 
         StepperRow {
@@ -144,7 +144,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.nexus.minHeight = v
-            onReset: { TokenConfig.sizes.nexus.minHeight = TokenConfig.defaults().sizes.nexus.minHeight; TokenConfig.sizes.nexus.resetOption("minHeight"); }
+            onReset: { TokenConfig.sizes.nexus.resetOption("minHeight"); }
         }
 
         StepperRow {
@@ -157,7 +157,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.nexus.maxNavWidth = v
-            onReset: { TokenConfig.sizes.nexus.maxNavWidth = TokenConfig.defaults().sizes.nexus.maxNavWidth; TokenConfig.sizes.nexus.resetOption("maxNavWidth"); }
+            onReset: { TokenConfig.sizes.nexus.resetOption("maxNavWidth"); }
         }
 
         StepperRow {
@@ -170,7 +170,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.nexus.maxContentWidth = v
-            onReset: { TokenConfig.sizes.nexus.maxContentWidth = TokenConfig.defaults().sizes.nexus.maxContentWidth; TokenConfig.sizes.nexus.resetOption("maxContentWidth"); }
+            onReset: { TokenConfig.sizes.nexus.resetOption("maxContentWidth"); }
         }
 
         StepperRow {
@@ -184,7 +184,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.nexus.popupWidth = v
-            onReset: { TokenConfig.sizes.nexus.popupWidth = TokenConfig.defaults().sizes.nexus.popupWidth; TokenConfig.sizes.nexus.resetOption("popupWidth"); }
+            onReset: { TokenConfig.sizes.nexus.resetOption("popupWidth"); }
         }
 
         SectionHeader {
@@ -199,7 +199,7 @@ PageBase {
             valueLabel: value.toFixed(2)
             showReset: true
             onMoved: v => TokenConfig.sizes.winfo.heightMult = v
-            onReset: { TokenConfig.sizes.winfo.heightMult = TokenConfig.defaults().sizes.winfo.heightMult; TokenConfig.sizes.winfo.resetOption("heightMult"); }
+            onReset: { TokenConfig.sizes.winfo.resetOption("heightMult"); }
         }
 
         StepperRow {
@@ -213,7 +213,7 @@ PageBase {
             stepSize: 10
             showReset: true
             onMoved: v => TokenConfig.sizes.winfo.detailsWidth = v
-            onReset: { TokenConfig.sizes.winfo.detailsWidth = TokenConfig.defaults().sizes.winfo.detailsWidth; TokenConfig.sizes.winfo.resetOption("detailsWidth"); }
+            onReset: { TokenConfig.sizes.winfo.resetOption("detailsWidth"); }
         }
     }
 }

--- a/plugin/src/Caelestia/Config/tokens.hpp
+++ b/plugin/src/Caelestia/Config/tokens.hpp
@@ -112,6 +112,7 @@ class BarTokens : public settings::ObjectNode {
     CONFIG_PROPERTY(int, trayMenuWidth, 300)
     CONFIG_PROPERTY(int, batteryWidth, 250)
     CONFIG_PROPERTY(int, networkWidth, 320)
+    CONFIG_PROPERTY(int, audioWidth, 320)
     CONFIG_PROPERTY(int, kbLayoutWidth, 320)
 };
 

--- a/plugin/src/Caelestia/I18n/Tr.qml
+++ b/plugin/src/Caelestia/I18n/Tr.qml
@@ -3,28 +3,32 @@ pragma Singleton
 import Caelestia.I18n
 
 TranslatorInternal {
+    // No-op so the flag var isn't optimised away
+    function _unused(v: var): void {
+    }
+
     function tr(text: string): string {
-        __trsChanged;
+        _unused(__trsChanged);
         return _tr(text, "", false);
     }
 
     function trCtx(text: string, context: string): string {
-        __trsChanged;
+        _unused(__trsChanged);
         return _tr(text, context, false);
     }
 
     function trN(text: string, plural: string, n: int): string {
-        __trsChanged;
+        _unused(__trsChanged);
         return _trN(text, plural, n, "");
     }
 
     function trCtxN(text: string, plural: string, n: int, context: string): string {
-        __trsChanged;
+        _unused(__trsChanged);
         return _trN(text, plural, n, context);
     }
 
     function trMarked(text: string): string {
-        __trsChanged;
+        _unused(__trsChanged);
         return _tr(text, "", true);
     }
 }

--- a/plugin/src/Caelestia/Services/CMakeLists.txt
+++ b/plugin/src/Caelestia/Services/CMakeLists.txt
@@ -22,6 +22,7 @@ qml_module(caelestia-services
         hyprdevices.cpp
         hyprextras.cpp
     LIBRARIES
+        Qt::Concurrent
         Qt::DBus
         Qt::Network
         PkgConfig::Pipewire

--- a/plugin/src/Caelestia/Services/storage.cpp
+++ b/plugin/src/Caelestia/Services/storage.cpp
@@ -5,6 +5,7 @@
 #include <qfileinfo.h>
 #include <qhash.h>
 #include <qstorageinfo.h>
+#include <qtconcurrentrun.h>
 
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
@@ -93,7 +94,12 @@ QStringList resolveByDevt(uint major, uint minor, int depth) {
 } // namespace
 
 Storage::Storage(QObject* parent)
-    : TickingService(parent) {}
+    : TickingService(parent)
+    , m_futureWatcher(new QFutureWatcher<AccumHash>(this)) {
+    QObject::connect(m_futureWatcher, &QFutureWatcher<AccumHash>::finished, this, [this] {
+        applyDisks(m_futureWatcher->result());
+    });
+}
 
 qreal Storage::percentage() const {
     qreal totalUsed = 0.0;
@@ -225,8 +231,8 @@ QHash<QByteArray, Storage::DeviceEntry> Storage::collectDevices() {
     return byDevice;
 }
 
-QHash<QString, Storage::Accum> Storage::foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice) {
-    QHash<QString, Accum> byDisk;
+Storage::AccumHash Storage::foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice) {
+    AccumHash byDisk;
 
     for (auto it = byDevice.constBegin(); it != byDevice.constEnd(); ++it) {
         const auto& e = it.value();
@@ -268,8 +274,16 @@ QHash<QString, Storage::Accum> Storage::foldToDisks(const QHash<QByteArray, Devi
 }
 
 void Storage::tick() {
+    if (m_futureWatcher->isRunning())
+        return;
+
+    m_futureWatcher->setFuture(QtConcurrent::run([] {
+        return foldToDisks(collectDevices());
+    }));
+}
+
+void Storage::applyDisks(const AccumHash& byDisk) {
     const auto prevPercentage = percentage();
-    const auto byDisk = foldToDisks(collectDevices());
 
     QHash<QString, DiskInfo*> existing;
     existing.reserve(m_disks.size());

--- a/plugin/src/Caelestia/Services/storage.hpp
+++ b/plugin/src/Caelestia/Services/storage.hpp
@@ -2,6 +2,7 @@
 
 #include <qbytearray.h>
 #include <qbytearrayview.h>
+#include <qfuturewatcher.h>
 #include <qhash.h>
 #include <qpointer.h>
 #include <qqmlintegration.h>
@@ -50,6 +51,8 @@ private:
         bool hasRoot = false;
     };
 
+    using AccumHash = QHash<QString, Accum>;
+
     // Mounts sharing a backing filesystem report identical usage, so they are deduped by source device first
     struct DeviceEntry {
         quint64 totalBytes = 0;
@@ -60,7 +63,9 @@ private:
     };
 
     [[nodiscard]] static QHash<QByteArray, DeviceEntry> collectDevices();
-    [[nodiscard]] static QHash<QString, Accum> foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice);
+    [[nodiscard]] static AccumHash foldToDisks(const QHash<QByteArray, DeviceEntry>& byDevice);
+
+    void applyDisks(const AccumHash& byDisk);
 
     [[nodiscard]] static QStringList resolveToPhysicalDisks(const QString& devicePath);
     [[nodiscard]] static bool isPseudoFs(QByteArrayView fsType);
@@ -71,6 +76,7 @@ private:
 
     QList<DiskInfo*> m_disks;
     QPointer<DiskInfo> m_manualPrimaryDisk;
+    QFutureWatcher<AccumHash>* const m_futureWatcher;
 };
 
 } // namespace caelestia::services

--- a/plugin/src/Caelestia/cutils.cpp
+++ b/plugin/src/Caelestia/cutils.cpp
@@ -49,6 +49,10 @@ void CUtils::saveItem(
     }
 
     const auto grabResult = target->grabToImage();
+    if (!grabResult) {
+        qCWarning(lcCUtils) << "saveItem: failed to grab" << target;
+        return;
+    }
 
     QObject::connect(
         grabResult.data(), &QQuickItemGrabResult::ready, this, [grabResult, scaledRect, path, onSaved, onFailed, this] {


### PR DESCRIPTION
Small one: brings in 5 upstream commits — async storage disk collection (#1986), nexus language setter (#1985), null-check grabToImage in saveItem (#1973), constrained audio device labels (#1958), CI PR-workflow scoping (#1980).\n\n#1958's fillWidth fix was ported onto the fork's card-based audio popout (fork sizing/sidebar-aware width kept). Everything else auto-merged. Full local build passes (244/244).