### PR TITLE
fix: Global-target settings not applying live

### DIFF
--- a/modules/nexus/common/PageBase.qml
+++ b/modules/nexus/common/PageBase.qml
@@ -14,7 +14,7 @@ ColumnLayout {
 
     required property string title
     required property NexusState nState
-    readonly property var targetConfig: GlobalConfig.forScreen(nState.targetScreen)
+    readonly property var targetConfig: nState.targetScreen === "" ? GlobalConfig : GlobalConfig.forScreen(nState.targetScreen)
     property bool isSubPage
     property bool scrollable: true
     readonly property int cappedWidth: Math.min(Tokens.sizes.nexus.maxContentWidth, width)

--- a/plugin/src/Caelestia/Config/rootnodes.cpp
+++ b/plugin/src/Caelestia/Config/rootnodes.cpp
@@ -95,6 +95,8 @@ TokensRoot::TokensRoot(const QString& path, TokensRoot* fallback, QObject* paren
     }                                                                                                                  \
                                                                                                                        \
     Root* Type::forScreen(const QString& screen) {                                                                     \
+        if (screen.isEmpty())                                                                                          \
+            return this; /* "Global" target — apply to the global root, not a phantom monitor layer */               \
         bool created;                                                                                                  \
         auto* const layer = m_layers.get(screen, this, &created);                                                      \
         if (created)                                                                                                   \


### PR DESCRIPTION
routes the Nexus global target to the global root instead of a phantom monitor layer, so settings changed with the Global target apply live and persist to shell.json
also types pagebase's targetConfig as var since forScreen returns the base class
